### PR TITLE
hide tooltips on toggle

### DIFF
--- a/app/src/components/lesson/lessonBuilder/LessonBuilder.component.vue
+++ b/app/src/components/lesson/lessonBuilder/LessonBuilder.component.vue
@@ -69,6 +69,7 @@ const formIsValid = ref(false);
 const components = lessonFormStore.getComponents;
 const lessons = lessonStore.getLessons;
 const {canDrop, isOver} = toRefs(collect);
+const showToolTips = ref<boolean>(false);
 
 async function validate() {
   await form.value.validate();
@@ -77,7 +78,7 @@ async function validate() {
 async function uploadLesson() {
   await validate();
 
-  if(!formIsValid.value) {
+  if (!formIsValid.value) {
     return;
   }
 
@@ -191,7 +192,16 @@ async function uploadLesson() {
               color="primary"
           >
             <v-col v-for="template in templates" :key="template">
-              <LessonModuleBox :title="template"/>
+              <LessonModuleBox :title="template" :show-tool-tip="showToolTips" :key="template"/>
+            </v-col>
+            <v-col>
+              <v-switch
+                  v-model="showToolTips"
+                  inset
+                  label="Beschreibungen einblenden"
+                  :true-value="true"
+                  :false-value="false"
+              ></v-switch>
             </v-col>
           </v-card>
         </v-col>
@@ -238,7 +248,6 @@ async function uploadLesson() {
           </v-card>
         </v-col>
       </v-row>
-
     </v-form>
   </v-container>
 </template>

--- a/app/src/components/lesson/lessonBuilder/LessonModuleBox.component.vue
+++ b/app/src/components/lesson/lessonBuilder/LessonModuleBox.component.vue
@@ -6,7 +6,8 @@ import {toRefs} from '@vueuse/core'
 import {vElementHover} from "@vueuse/components";
 
 const props = defineProps<{
-  title: string
+  title: string,
+  showToolTip: boolean
 }>();
 
 const [collect, drag] = useDrag(() => ({
@@ -29,7 +30,7 @@ const componentsTranslationMap: Record<string, { title: string, tooltip: string 
   'Note': {title: 'Notizen', tooltip: 'Ein Freitextfeld für Notizen des Studenten'},
 };
 
-const { isDragging } = toRefs(collect);
+const {isDragging} = toRefs(collect);
 const isHovered = ref(false);
 
 const translatedTitle = computed(() => {
@@ -52,18 +53,18 @@ function onHover(state: boolean) {
       :ref="drag"
       :style="{ opacity: isDragging ? 0.3 : 1 }"
   >
-        <v-card
-            v-element-hover="onHover"
-            :variant="isHovered ? 'outlined' : 'elevated'"
-            border
-            ripple
-            density="compact"
-            :title="translatedTitle"
-        >
-          <v-tooltip location="bottom" activator="parent">
-            {{ translatedTooltip }}
-          </v-tooltip>
-        </v-card>
+    <v-card
+        v-element-hover="onHover"
+        :variant="isHovered ? 'outlined' : 'elevated'"
+        border
+        ripple
+        density="compact"
+        :title="translatedTitle"
+    >
+      <v-tooltip v-if="showToolTip" location="bottom" activator="parent">
+        {{ translatedTooltip }}
+      </v-tooltip>
+    </v-card>
   </div>
 </template>
 


### PR DESCRIPTION
Per Toggle mit einem v-switch können die tooltips im Lektionsbuilder nun versteckt oder wieder angezeigt werden. Der default ist false, also verstecken, so dass man bei häufigem Betreten der Seite nicht jedes Mal die Hinweise verstecken muss, wenn man sich bereits auskennt. 
Es wird ein boolean showToolTips mit true oder false an die ModuleBox über props weitergegeben, wodurch dann die tooltip Anzeige kontrolliert werden kann.
Der Switch wurde unterhalb der ModuleBoxes in der Card platziert, um zu suggerieren, worauf sich der Switch bezieht und um welche Beschreibungen es sich handelt.