### PR TITLE
do not show hints if string is empty

### DIFF
--- a/app/src/components/lesson/lessonBuilder/Hint.component.vue
+++ b/app/src/components/lesson/lessonBuilder/Hint.component.vue
@@ -34,7 +34,7 @@ async function onHintClick() {
 </script>
 
 <template>
-  <v-tooltip :text="'Hinweis'" location="top">
+  <v-tooltip :text="'Hinweis'" location="top" v-if="hint.trim() !== ''">
     <template v-slot:activator="{ props }">
       <v-btn v-bind="props"
              size="40"


### PR DESCRIPTION
Wenn aus der Datenbank ein leerer String oder ein mit Leerzeichen gefüllter String geladen wird, wird dieser nicht angezeigt. 
