### PR TITLE
Hinweise ohne Punktabzug oder Warnung anzeigen 

### DIFF
--- a/app/src/components/lesson/lessonBuilder/Hint.component.vue
+++ b/app/src/components/lesson/lessonBuilder/Hint.component.vue
@@ -14,7 +14,7 @@ const lessonStore = useLessonStore();
 const authStore = useAuthStore();
 
 function openWarningDialog() {
-  if (authStore.isTeacher) {
+  if (authStore.isTeacher || (!lessonStore.currentLesson?.isStarted && lessonStore.currentLesson?.isFinished)) {
     openHintDialog();
   } else {
     alertService.openDialog('Warnung: Hinweise anzeigen',


### PR DESCRIPTION
Hinweise werden in den Lösungen ohne Punkteabzüge oder Warnungen angezeigt. 