### PR TITLE
Close Dialog on click outside 

### DIFF
--- a/app/src/components/util/CustomDialog.component.vue
+++ b/app/src/components/util/CustomDialog.component.vue
@@ -50,7 +50,7 @@ openDialog.value = props.modelValue;
 </script>
 
 <template>
-  <v-dialog v-model="openDialog" max-width="800px" persistent>
+  <v-dialog @click:outside="cancel" v-model="openDialog" max-width="800px">
     <v-card variant="elevated" class="pa-4">
       <v-row>
         <v-col cols="1" class="d-flex align-center">


### PR DESCRIPTION
Persistent wurde vom Dialog entfernt und stattdessen wird die Funktion cancel nun auch aufgerufen, wenn man außerhalb des Dialoges klickt.