### PR TITLE
Punkteberechnung überarbeiten 

### DIFF
--- a/supabase/database/functions/answer.sql
+++ b/supabase/database/functions/answer.sql
@@ -108,6 +108,13 @@ BEGIN
 
     ELSE
         IF (lesson_started) THEN
+            UPDATE user_finished_lessons
+            SET finished                = TRUE,
+                is_started              = FALSE,
+                finished_for_first_time = FALSE
+            WHERE lesson_id = lesson_uuid
+              AND user_id = auth.uid();
+
             FOR newAnswer IN
                 SELECT *
                 FROM jsonb_array_elements(data -> 'answers')
@@ -144,13 +151,6 @@ BEGIN
                         END IF;
                     END IF;
                 END LOOP;
-
-            UPDATE user_finished_lessons
-            SET finished                = TRUE,
-                is_started              = FALSE,
-                finished_for_first_time = FALSE
-            WHERE lesson_id = lesson_uuid
-              AND user_id = auth.uid();
         END IF;
     END IF;
 END;


### PR DESCRIPTION
#132 Es wird für den Update und Insert Trigger auf die user answers nun die gleiche Funktion aufgerufen, um die Antworten zu evaluieren. Dadurch wird doppelter Code vermieden. Ob die Punkte addiert werden sollen oder nicht, ist nun abhängig von dem Attribut der Lektion, ob sie zum ersten Mal abgeschlossen wurde. 
Dieser Wert wird bevor die Antworten evaluiert werden aktualisiert. 
Dadurch sollten Punkte nicht mehr fälschlicherweise zusammenaddiert werden.