### PR TITLE
144 katalogtabelle durch vuetify component ersetzen

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,6 @@
     "vue-bpmn": "^0.3.0",
     "vue-router": "^4.3.2",
     "vue3-dnd": "^2.1.0",
-    "vue3-easy-data-table": "^1.5.47",
     "vuetify": "^3.6.7",
     "webfontloader": "^1.6.28",
     "xlsx": "^0.18.5"

--- a/app/src/components/catalog/CatalogTable.vue
+++ b/app/src/components/catalog/CatalogTable.vue
@@ -1,105 +1,46 @@
 <script setup lang="ts">
-import {Requirement} from "@/types/catalog.ts";
-import { computed } from "vue";
-
-// EasyDataTable with MIT Licence (LICENCE.txt) from: https://github.com/HC200ok/vue3-easy-data-table
+import {Product, Requirement} from "@/types/catalog.ts";
+import {ref} from "vue";
+import ProductPanel from "@/components/catalog/product/ProductPanel.vue";
 
 interface Props {
-  selectable: boolean,
-  modelValue: Requirement[],
   requirementItems: Requirement[],
-  loading: boolean
+  loading: boolean,
+  products: Product[]
 }
 
 const props = defineProps<Props>();
+const expanded = ref<any>([]);
 
 const headers = [
-  {text: 'Requirement', value: 'reqId', sortable: true},
-  {text: 'Titel', value: 'title', sortable: true},
-  {text: 'Beschreibung', value: 'description', sortable: true},
+  {title: 'Anforderung', value: 'reqId', sortable: true},
+  {title: 'Titel', value: 'title', sortable: true},
+  {title: 'Beschreibung', value: 'description', sortable: true},
 ]
-
-const emit = defineEmits(['onRowClick', 'update:modelValue'])
-
-async function onRowClick(item: Requirement) {
-  emit('onRowClick', item)
-}
-
-const selectedItems = computed({
-  get() {
-    return props.modelValue;
-  },
-  set(newValue) {
-    emit('update:modelValue', newValue);
-  }
-})
-
 </script>
 
 <template>
-  <EasyDataTable v-if="selectable"
-                 :headers="headers"
-                 :items="requirementItems"
-                 :loading="loading"
-                 :rows-items="[5, 10, 15, 25, 50]"
-                 :rows-per-page="10"
-                 v-model:items-selected="selectedItems"
-                 table-class-name="customize-table"
-                 @click-row="onRowClick">
-  </EasyDataTable>
-
-  <EasyDataTable v-if="!selectable"
-                 :headers="headers"
-                 :items="requirementItems"
-                 :loading="loading"
-                 :rows-items="[5, 10, 15, 25, 50]"
-                 :rows-per-page="10"
-                 table-class-name="customize-table"
-                 @click-row="onRowClick">
-  </EasyDataTable>
+  <v-data-table
+      v-model:expanded="expanded"
+      :headers="headers"
+      :items="requirementItems"
+      item-value="requirement_id"
+      show-expand
+      expand-on-click
+      hover
+      items-per-page="15"
+  >
+    <template v-slot:top>
+      <v-toolbar border color="primary">
+        <v-toolbar-title>Anforderungskatalog</v-toolbar-title>
+      </v-toolbar>
+    </template>
+    <template v-slot:expanded-row="{ columns, item }">
+      <tr>
+        <td :colspan="columns.length">
+          <ProductPanel :requirement="item" :products="products"></ProductPanel>
+        </td>
+      </tr>
+    </template>
+  </v-data-table>
 </template>
-
-<style scoped>
-
-.customize-table {
-  --easy-table-border: 1px solid rgb(var(--v-theme-primary));
-  --easy-table-row-border: 1px solid rgb(var(--v-theme-primary));
-
-  --easy-table-header-font-size: 14px;
-  --easy-table-header-height: 50px;
-  --easy-table-header-font-color: white;
-  --easy-table-header-background-color: rgb(var(--v-theme-primary));
-
-  --easy-table-header-item-padding: 10px 15px;
-
-  --easy-table-body-even-row-font-color: #fff;
-  --easy-table-body-even-row-background-color: #4c5d7a;
-
-  --easy-table-body-row-font-color: rgb(var(--v-theme-textColor));
-  --easy-table-body-row-background-color: rgb(var(--v-theme-background));
-  --easy-table-body-row-height: 50px;
-  --easy-table-body-row-font-size: 14px;
-
-  --easy-table-body-row-hover-font-color: #2d3a4f;
-  --easy-table-body-row-hover-background-color: rgb(var(--v-theme-highlightColor));
-
-  --easy-table-body-item-padding: 10px 15px;
-
-  --easy-table-footer-background-color: rgb(var(--v-theme-primary));
-  --easy-table-footer-font-color: white;
-  --easy-table-footer-font-size: 14px;
-  --easy-table-footer-padding: 0px 10px;
-  --easy-table-footer-height: 50px;
-
-  --easy-table-rows-per-page-selector-width: 70px;
-  --easy-table-rows-per-page-selector-option-padding: 10px;
-  --easy-table-rows-per-page-selector-z-index: 1;
-
-  --easy-table-scrollbar-track-color: #2d3a4f;
-  --easy-table-scrollbar-color: #2d3a4f;
-  --easy-table-scrollbar-thumb-color: #4c5d7a;;
-  --easy-table-scrollbar-corner-color: #2d3a4f;
-
-  --easy-table-loading-mask-background-color: rgb(var(--v-theme-surface));
-}
-</style>

--- a/app/src/components/catalog/product/ProductPanel.vue
+++ b/app/src/components/catalog/product/ProductPanel.vue
@@ -2,29 +2,44 @@
 
 import {Product, Requirement} from "@/types/catalog.ts";
 import ProductDetail from "@/components/catalog/product/ProductDetail.vue"
+import AlertService from "@/services/util/alert.ts";
+import {onBeforeMount, ref} from "vue";
+import {useCatalogStore} from "@/stores/catalog.ts";
 
 interface Props {
   requirement: Requirement | undefined,
-  products: Product[],
-  loading: boolean
+  products: Product[]
 }
 
+const loading = ref<boolean>(false);
 const props = defineProps<Props>();
+
+const catalogStore = useCatalogStore();
+
+async function getProductDetails() {
+
+  try {
+    if (props.requirement) {
+      await catalogStore.getProductDetailsForRequirement(props.requirement, props.products);
+    }
+  } catch (error: any) {
+    AlertService.addErrorAlert("Fehler beim Abrufen der Produktdetails: " + error.message);
+  }
+
+}
+onBeforeMount(async () => {
+  loading.value = true;
+  await getProductDetails();
+  loading.value = false;
+})
 </script>
 
 <template>
-  <v-expansion-panels>
-    <v-expansion-panel v-if="requirement">
-      <v-expansion-panel-title>
-        Produktdetails zur Anforderung
-      </v-expansion-panel-title>
-      <v-expansion-panel-text>
-        <v-row v-if="requirement">
-          <v-col v-for="product in products" :key="product.product_name" cols="12" md="6" lg="4">
-            <ProductDetail :requirement="requirement" :loading="loading" :product="product"/>
-          </v-col>
-        </v-row>
-      </v-expansion-panel-text>
-    </v-expansion-panel>
-  </v-expansion-panels>
+  <v-card :loading="loading" variant="flat" title="Produktdetails" class="pb-5 mt-2 mb-2">
+    <v-row v-if="requirement">
+      <v-col v-for="product in products" :key="product.product_name" cols="12" md="6" lg="4">
+        <ProductDetail :requirement="requirement" :loading="loading" :product="product"/>
+      </v-col>
+    </v-row>
+  </v-card>
 </template>

--- a/app/src/plugins/index.ts
+++ b/app/src/plugins/index.ts
@@ -9,9 +9,6 @@ import {loadFonts} from "./webfontloader";
 import vuetify from "./vuetify";
 import pinia from "./pinia";
 import router from "../router";
-import Vue3EasyDataTable from 'vue3-easy-data-table';
-// EasyDataTable with MIT Licence (LICENCE.txt) from: https://github.com/HC200ok/vue3-easy-data-table
-import 'vue3-easy-data-table/dist/style.css';
 
 // Types
 import type {App} from "vue";
@@ -22,7 +19,6 @@ import {errorHandler} from "@/errors/handler.ts";
 export function registerPlugins(app: App) {
   loadFonts();
   app.use(vuetify).use(router).use(pinia);
-  app.component('EasyDataTable', Vue3EasyDataTable);
 }
 
 export function addErrorHandlers(app: App) {

--- a/app/src/views/catalog/CatalogDetail.vue
+++ b/app/src/views/catalog/CatalogDetail.vue
@@ -2,11 +2,9 @@
 import {useCatalogStore} from "@/stores/catalog.ts";
 import {Catalog, Product, Requirement} from "@/types/catalog.ts";
 import AlertService from "@/services/util/alert.ts";
-import ProductPanel from "@/components/catalog/product/ProductPanel.vue";
-import RequirementItem from "@/components/catalog/requirement/Requirement.vue";
-import CatalogTable from "@/components/catalog/CatalogTable.vue";
 import { onBeforeMount, ref } from "vue";
 import { useRoute } from "vue-router";
+import CatalogTable from "@/components/catalog/CatalogTable.vue";
 
 const catalog = ref<Catalog>();
 const catalogProducts = ref<Product[]>([]);
@@ -14,28 +12,7 @@ const catalogStore = useCatalogStore();
 let catalogIdAsNumber: number = 0;
 
 const loading = ref<boolean>(true);
-const loadingBar = ref<boolean>(false);
-
 const requirementItems = ref<Requirement[]>([]);
-const selectedRequirement = ref<Requirement>();
-const reqGroupSelection = ref<Requirement[]>([]);
-
-async function onRowClick(item: Requirement) {
-  selectedRequirement.value = item;
-  await getProductDetails();
-}
-
-async function getProductDetails() {
-  loadingBar.value = true;
-  try {
-    if (selectedRequirement.value) {
-      await catalogStore.getProductDetailsForRequirement(selectedRequirement.value, catalogProducts.value);
-    }
-  } catch (error: any) {
-    AlertService.addErrorAlert("Fehler beim Abrufen der Produktdetails: " + error.message);
-  }
-  loadingBar.value = false;
-}
 
 onBeforeMount(async () => {
   const route = useRoute();
@@ -69,23 +46,10 @@ function setUpCatalog() {
     </v-col>
   </v-row>
   <v-divider/>
-  <v-container>
+  <v-container class="mt-2">
     <v-row>
       <v-col>
-        <RequirementItem :requirement="selectedRequirement"></RequirementItem>
-      </v-col>
-      <v-col>
-        <ProductPanel :requirement="selectedRequirement" :products="catalogProducts"
-                      :loading="loadingBar"></ProductPanel>
-      </v-col>
-    </v-row>
-
-    <v-row>
-      <v-col>
-        <CatalogTable :loading="loading" :requirement-items="requirementItems" v-model="reqGroupSelection"
-                      :selectable="false"
-                      @on-row-click="onRowClick"
-        ></CatalogTable>
+        <CatalogTable :products="catalogProducts" :loading="loading" :requirement-items="requirementItems"></CatalogTable>
       </v-col>
     </v-row>
   </v-container>


### PR DESCRIPTION
Die Easy-Data-Table wurde nun entfernt und durch die Data Table von vuetify ersetzt. Die Komponente ProductPanel für die Produkte-Ansicht wurde dafür leicht angepasst. 
Produkte lassen sich nun per Klick auf die Reihe anzeigen, indem die Reihe expanded wird.