### PR TITLE
197 lernziele erstellen

### DIFF
--- a/app/src/components/learningGoals/EditLearningGoal.vue
+++ b/app/src/components/learningGoals/EditLearningGoal.vue
@@ -38,17 +38,12 @@
 
 <script setup lang="ts">
 import { onBeforeMount, ref } from "vue";
-import { Product } from "@/types/catalog.ts";
 import AlertService from "@/services/util/alert.ts";
 import {
   maxLengthRule,
-  minMaxWords,
-  requiredNumberRule,
   requiredPositiveNumberRule,
-  requiredProductUrlRule,
   requiredStringRule
 } from "@/utils/validationRules.ts";
-import { useProductStore } from "@/stores/product.ts";
 import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
 import {LearningGoal} from "@/types/learningGoals.ts";
 
@@ -60,7 +55,7 @@ defineProps<Props>();
 const emit = defineEmits(["update:dialog"]);
 const learningGoalStore = useLearningGoalsStore();
 const isFormValid = ref<boolean>(false);
-const localGoal = ref<LearningGoal>({id: "", name: "", description: ""});
+const localGoal = ref<LearningGoal>({id: "", name: "", description: "", max_level: 5});
 const originalGoal = ref<LearningGoal>();
 
 function close() {

--- a/app/src/components/learningGoals/EditLearningGoal.vue
+++ b/app/src/components/learningGoals/EditLearningGoal.vue
@@ -1,0 +1,113 @@
+<template>
+  <v-dialog
+      :model-value="dialog"
+      @update:model-value="close"
+      opacity="0.3"
+      max-width="900"
+  >
+    <v-form v-model="isFormValid" @submit.prevent="save" ref="form">
+      <v-card variant="elevated" class="pa-1">
+        <v-card-title v-if="localGoal.id.length > 0">Produkt bearbeiten</v-card-title>
+        <v-card-title v-if="localGoal.id.length <= 0">Produkt erstellen</v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <div class="text-caption mb-2">
+                Lernziel
+              </div>
+              <v-text-field variant="outlined" label="Name" v-model="localGoal.name"
+                            :rules="[requiredStringRule]"/>
+              <v-text-field variant="outlined" label="Beschreibung" v-model="localGoal.description"
+                            :rules="[requiredStringRule, maxLengthRule]"/>
+              <v-text-field variant="outlined" label="Maximales Level" type="number" v-model="localGoal.max_level"
+                            :rules="[requiredPositiveNumberRule]"/>
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="success" type="submit"
+                 :disabled="!isFormValid">Speichern
+          </v-btn>
+          <v-btn color="info" @click="close">Schließen</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { onBeforeMount, ref } from "vue";
+import { Product } from "@/types/catalog.ts";
+import AlertService from "@/services/util/alert.ts";
+import {
+  maxLengthRule,
+  minMaxWords,
+  requiredNumberRule,
+  requiredPositiveNumberRule,
+  requiredProductUrlRule,
+  requiredStringRule
+} from "@/utils/validationRules.ts";
+import { useProductStore } from "@/stores/product.ts";
+import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
+import {LearningGoal} from "@/types/learningGoals.ts";
+
+interface Props {
+  dialog: boolean;
+}
+
+defineProps<Props>();
+const emit = defineEmits(["update:dialog"]);
+const learningGoalStore = useLearningGoalsStore();
+const isFormValid = ref<boolean>(false);
+const localGoal = ref<LearningGoal>({id: "", name: "", description: ""});
+const originalGoal = ref<LearningGoal>();
+
+function close() {
+  emit("update:dialog", false);
+}
+
+async function save() {
+  if (originalGoal.value && localGoal.value) {
+    if (!areGoalsEqual(originalGoal.value, localGoal.value)) {
+      await updateLearningGoal();
+    } else {
+      AlertService.addInfoAlert("Es wurden keine Änderungen vorgenommen.")
+      return;
+    }
+  } else if (!originalGoal.value && localGoal.value) {
+    await createLearningGoal();
+  }
+
+  emit("update:dialog", false);
+}
+
+async function updateLearningGoal() {
+  try {
+    await learningGoalStore.updateCurrentLearningGoal(localGoal.value);
+    AlertService.addSuccessAlert("Lernziel wurde aktualisiert.")
+  } catch (error: any) {
+    throw error;
+  }
+}
+
+async function createLearningGoal() {
+  try {
+    await learningGoalStore.uploadLearningGoal(localGoal.value);
+    AlertService.addSuccessAlert("Lernziel wurde erstellt.")
+  } catch (error: any) {
+    throw error;
+  }
+}
+
+function areGoalsEqual(original: LearningGoal, edited: LearningGoal) {
+  return JSON.stringify(original) === JSON.stringify(edited);
+}
+
+onBeforeMount(async () => {
+  if (learningGoalStore.getCurrentLearningGoal) {
+    originalGoal.value = learningGoalStore.getCurrentLearningGoal;
+    localGoal.value = JSON.parse(JSON.stringify(originalGoal.value));
+  }
+});
+</script>

--- a/app/src/components/learningGoals/LearningGoalsTable.vue
+++ b/app/src/components/learningGoals/LearningGoalsTable.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-data-table-virtual
+      class="mt-5"
+      v-model:expanded="expanded"
+      :headers="headers"
+      :items="learningGoalsStore.getCurrentLearningGoals ? learningGoalsStore.getCurrentLearningGoals : []"
+      item-value="id"
+      hover
+      height="70vh"
+      no-data-text="Sie haben noch keine Lernziele erstellt."
+  >
+    <template v-slot:item.actions="{ item }">
+      <div>
+        <v-btn
+            class="ml-1"
+            density="compact"
+            color="success"
+            variant="plain"
+            size="medium"
+            icon="mdi-pencil"
+            @click.stop="openEditDialog(item)"
+        />
+        <v-btn
+            class="ml-2"
+            density="compact"
+            color="error"
+            variant="plain"
+            size="medium"
+            icon="mdi-delete"
+            @click.stop="deleteLearningGoal(item)"
+        />
+      </div>
+    </template>
+  </v-data-table-virtual>
+  <EditLearningGoal v-if="editDialog" :dialog="editDialog" @update:dialog="updateEditDialog"></EditLearningGoal>
+</template>
+
+<script setup lang="ts">
+import { ref } from "vue";
+import {DeleteLearningGoal} from "@/utils/dialogs.ts";
+import { useUtilStore } from "@/stores/util.ts";
+import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
+import {LearningGoal} from "@/types/learningGoals.ts";
+import EditLearningGoal from "@/components/learningGoals/EditLearningGoal.vue";
+
+const expanded = ref<any>([]);
+const utilStore = useUtilStore();
+const editDialog = ref<boolean>(false);
+
+const learningGoalsStore = useLearningGoalsStore();
+
+const headers = ref([
+  { title: "Name", value: "name", sortable: true, width: "25%", align: "start" },
+  { title: "Beschreibung", value: "description", sortable: true, width: "auto", align: "center" },
+  { title: "Maximales Level", value: "max_level", sortable: true, width: "auto", align: "center" },
+  { title: "Aktionen", value: "actions", sortable: false, width: "auto", align: "end" }
+] as const);
+
+function openEditDialog(item: LearningGoal | null) {
+  if (item) {
+    learningGoalsStore.currentLearningGoal = item;
+    editDialog.value = true;
+  }
+}
+
+function updateEditDialog(value: boolean) {
+  editDialog.value = value;
+}
+
+function deleteLearningGoal(item: LearningGoal) {
+  utilStore.openDialog(DeleteLearningGoal, () => {
+    learningGoalsStore.deleteLearningGoalById(item.id);
+  });
+}
+</script>

--- a/app/src/layouts/Default.vue
+++ b/app/src/layouts/Default.vue
@@ -6,12 +6,12 @@
                        :active="utilStore.showLoadingBar"
     />
     <v-navigation-drawer
-      location="left"
-      width="250"
-      expand-on-hover
-      v-model:rail="rail"
-      v-model="drawer"
-      permanent
+        location="left"
+        width="250"
+        expand-on-hover
+        v-model:rail="rail"
+        v-model="drawer"
+        permanent
     >
       <v-list nav>
         <v-list-item v-if="authStore.user"
@@ -30,43 +30,43 @@
                      rounded
         />
       </v-list>
-      <v-divider class="my-1" />
+      <v-divider class="my-1"/>
       <v-list nav>
         <v-list-item
-          rounded prepend-icon="mdi-home"
-          title="Home" to="/"
-          exact />
-        <v-divider class="my-1" />
+            rounded prepend-icon="mdi-home"
+            title="Home" to="/"
+            exact/>
+        <v-divider class="my-1"/>
         <div v-if="authStore.user">
           <v-list-group value="Lektionen" v-if="!authStore.isTeacher">
             <template v-slot:activator="{ props }">
               <v-list-item
-                v-bind="props"
-                prepend-icon="mdi-school"
-                title="Lernen"
-                rounded
+                  v-bind="props"
+                  prepend-icon="mdi-school"
+                  title="Lernen"
+                  rounded
               />
             </template>
             <v-list-item
-              rounded
-              to="/lessons"
-              title="Lektionen"
-              :active="router.currentRoute.value.path.startsWith('/lessons')"
-              :subtitle="lessonStore.openLessons <= 0 ? 'Keine offenen' : lessonStore.openLessons +' Lektion(en) offen'"
+                rounded
+                to="/lessons"
+                title="Lektionen"
+                :active="router.currentRoute.value.path.startsWith('/lessons')"
+                :subtitle="lessonStore.openLessons <= 0 ? 'Keine offenen' : lessonStore.openLessons +' Lektion(en) offen'"
             >
               <template v-slot:prepend>
                 <v-progress-circular
-                  class="mr-4"
-                  size="27"
-                  :model-value="openLessonsPercentage"
-                  :color="openLessonsColor"
+                    class="mr-4"
+                    size="27"
+                    :model-value="openLessonsPercentage"
+                    :color="openLessonsColor"
                 />
               </template>
             </v-list-item>
             <v-list-item
-              title="Meine Punkte"
-              :subtitle="profileStore.points"
-              rounded
+                title="Meine Punkte"
+                :subtitle="profileStore.points"
+                rounded
             >
               <template v-slot:prepend>
                 <v-icon class="mr-n5 ml-n1" size="34" color="warning">
@@ -77,35 +77,36 @@
           </v-list-group>
         </div>
         <div v-if="authStore.user && authStore.isTeacher">
-          <v-list-item rounded prepend-icon="mdi-text-box-multiple" title="Meine Kataloge" to="/catalogs" />
-          <v-list-item rounded prepend-icon="mdi-invoice-list" title="Meine Produkte" to="/products" />
-          <v-list-item rounded prepend-icon="mdi-upload" title="Katalog Hochladen" to="/catalogs/upload" />
-          <v-divider class="my-1" />
+          <v-list-item rounded prepend-icon="mdi-text-box-multiple" title="Meine Kataloge" to="/catalogs"/>
+          <v-list-item rounded prepend-icon="mdi-invoice-list" title="Meine Produkte" to="/products"/>
+          <v-list-item rounded prepend-icon="mdi-trophy" title="Meine Lernziele" to="/learningGoals"/>
+          <v-list-item rounded prepend-icon="mdi-upload" title="Katalog Hochladen" to="/catalogs/upload"/>
+          <v-divider class="my-1"/>
           <v-list-item rounded prepend-icon="mdi-school" title="Erstellte Lektionen"
-                       :active="router.currentRoute.value.path.startsWith('/lessons')" to="/lessons" />
+                       :active="router.currentRoute.value.path.startsWith('/lessons')" to="/lessons"/>
           <!-- v-list-item rounded prepend-icon="mdi-graph-outline" title="Erstellte Szenarien" to="/modeler" /-->
-          <v-list-item rounded prepend-icon="mdi-tools" title="Lektionen Erstellen" to="/builder" />
-          <v-list-item rounded prepend-icon="mdi-application-array-outline" title="BPMN Modeler" to="/modeler" />
+          <v-list-item rounded prepend-icon="mdi-tools" title="Lektionen Erstellen" to="/builder"/>
+          <v-list-item rounded prepend-icon="mdi-application-array-outline" title="BPMN Modeler" to="/modeler"/>
         </div>
       </v-list>
       <template v-slot:append>
-        <v-divider class="my-1" />
+        <v-divider class="my-1"/>
         <v-list>
           <div v-if="authStore.user">
-            <v-list-item prepend-icon="mdi-cog" title="Account Einstellungen" to="/account" />
-            <v-list-item prepend-icon="mdi-logout" title="Logout" @click="logout" />
+            <v-list-item prepend-icon="mdi-cog" title="Account Einstellungen" to="/account"/>
+            <v-list-item prepend-icon="mdi-logout" title="Logout" @click="logout"/>
           </div>
           <v-list-item
-            :prepend-icon="themeStore.currentTheme === 'light' ? 'mdi-weather-night' : 'mdi-weather-sunny'"
-            :title="themeStore.currentTheme === 'light' ? 'Dunkles Thema' : 'Helles Thema'"
-            @click="themeStore.toggleUserTheme"
+              :prepend-icon="themeStore.currentTheme === 'light' ? 'mdi-weather-night' : 'mdi-weather-sunny'"
+              :title="themeStore.currentTheme === 'light' ? 'Dunkles Thema' : 'Helles Thema'"
+              @click="themeStore.toggleUserTheme"
           />
-          <v-divider class="my-1" />
-          <v-list-item prepend-icon="mdi-email-fast" title="Feedback" to="/feedback" />
+          <v-divider class="my-1"/>
+          <v-list-item prepend-icon="mdi-email-fast" title="Feedback" to="/feedback"/>
           <v-list-item
-            prepend-icon="mdi-scale-balance"
-            title="Rechtliche Hinweise"
-            to="/legal"
+              prepend-icon="mdi-scale-balance"
+              title="Rechtliche Hinweise"
+              to="/legal"
           />
         </v-list>
       </template>
@@ -116,13 +117,13 @@
           <v-col>
             <div v-for="alert in utilStore.alerts" :key="alert.id">
               <v-alert
-                closable
-                class="mb-2"
-                variant="outlined"
-                border="top"
-                density="compact"
-                :type="alert.type"
-                @click:close="utilStore.removeAlert(alert.id)"
+                  closable
+                  class="mb-2"
+                  variant="outlined"
+                  border="top"
+                  density="compact"
+                  :type="alert.type"
+                  @click:close="utilStore.removeAlert(alert.id)"
               >
                 {{ alert.message }}
               </v-alert>
@@ -152,13 +153,13 @@
 
 <script lang="ts" setup>
 import router from "@/router";
-import { useUtilStore } from "@/stores/util.ts";
-import { useAuthStore } from "@/stores/auth.ts";
-import { useThemeStore } from "@/stores/theme.ts";
+import {useUtilStore} from "@/stores/util.ts";
+import {useAuthStore} from "@/stores/auth.ts";
+import {useThemeStore} from "@/stores/theme.ts";
 import Dialog from "@/components/util/Dialog.vue";
-import { useProfileStore } from "@/stores/profile.ts";
-import { useLessonStore } from "@/stores/lesson.ts";
-import { onBeforeMount, ref, watch } from "vue";
+import {useProfileStore} from "@/stores/profile.ts";
+import {useLessonStore} from "@/stores/lesson.ts";
+import {onBeforeMount, ref, watch} from "vue";
 
 const utilStore = useUtilStore();
 const authStore = useAuthStore();
@@ -206,6 +207,6 @@ watch(() => lessonStore.openLessons, () => {
   }
   openLessonsColor.value = "warning";
   openLessonsPercentage.value = (lessonStore.openLessons / lessonStore.lessons.length) * 100;
-}, { immediate: true });
+}, {immediate: true});
 
 </script>

--- a/app/src/middlewares/learningGoals.ts
+++ b/app/src/middlewares/learningGoals.ts
@@ -1,0 +1,12 @@
+import { NavigationGuardNext, RouteLocationNormalized } from "vue-router";
+import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
+
+export async function fetchLearningGoalsByUser(to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) {
+    try {
+        const learningGoalsStore = useLearningGoalsStore();
+        await learningGoalsStore.fetchLearningGoals();
+        return next();
+    } catch (error) {
+        return next({name: 'Error'});
+    }
+}

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -7,8 +7,8 @@ import {
     Router
 } from "vue-router";
 
-import { requiresAuth, requiresStudent, requiresTeacher } from "@/middlewares/auth.ts";
-import { fetchCatalog, fetchCatalogs } from "@/middlewares/catalogs.ts";
+import {requiresAuth, requiresStudent, requiresTeacher} from "@/middlewares/auth.ts";
+import {fetchCatalog, fetchCatalogs} from "@/middlewares/catalogs.ts";
 import {
     fetchLessons,
     fetchQuestionsForLesson,
@@ -19,8 +19,9 @@ import {
     requiresFinishedLesson,
     requiresUnfinishedLesson
 } from "@/middlewares/lesson.ts";
-import { useUtilStore } from "@/stores/util.ts";
-import { fetchProductsByUser } from "@/middlewares/product.ts";
+import {useUtilStore} from "@/stores/util.ts";
+import {fetchProductsByUser} from "@/middlewares/product.ts";
+import {fetchLearningGoalsByUser} from "@/middlewares/learningGoals.ts";
 
 const routes = [
     {
@@ -136,6 +137,17 @@ const routes = [
                     middleware: [
                         requiresTeacher,
                         fetchProductsByUser
+                    ]
+                }
+            },
+            {
+                path: "/learningGoals",
+                name: "LearningGoals",
+                component: () => import("@/views/learningGoals/LearningGoalsOverview.vue"),
+                meta: {
+                    middleware: [
+                        requiresTeacher,
+                        fetchLearningGoalsByUser
                     ]
                 }
             },

--- a/app/src/services/database/learningGoals.ts
+++ b/app/src/services/database/learningGoals.ts
@@ -1,0 +1,80 @@
+import {supabase} from "@/plugins/supabase";
+import {LearningGoal, LearningGoalDTO} from "@/types/learningGoals.ts";
+
+class LearningGoalsServiceClass {
+
+    public push = {
+        uploadLearningGoal: this.uploadLearningGoal.bind(this),
+        updateLearningGoal: this.updateLearningGoal.bind(this),
+        deleteLearningGoal: this.deleteLearningGoal.bind(this)
+    };
+
+    public pull = {
+        fetchLearningGoalsByUser: this.fetchLearningGoalsByUser.bind(this),
+    };
+
+    private async fetchLearningGoalsByUser(userUUID: string): Promise<LearningGoal[] | undefined> {
+        const {data, error} = await supabase
+            .from("learning_goals")
+            .select("*")
+            .eq("user_id", userUUID)
+
+        if (error) throw error;
+
+        if (data) {
+            return data as LearningGoal[];
+        }
+    }
+
+    private async uploadLearningGoal(learningGoal: LearningGoal, userUUID: string): Promise<LearningGoal | undefined> {
+        const {data, error} = await supabase
+            .from('learning_goals')
+            .insert(
+                {
+                    user_id: userUUID,
+                    name: learningGoal.name,
+                    description: learningGoal.description,
+                    max_level: learningGoal.max_level
+                }
+            )
+            .select()
+
+        if (error) throw error;
+
+        return data[0] as LearningGoal;
+    }
+
+    private async updateLearningGoal(learningGoal: LearningGoal) {
+        if (!learningGoal.id) {
+            throw new Error("Learning goal Id not found.")
+        }
+        const {error} = await supabase
+            .from("learning_goals")
+            .update({
+                name: learningGoal.name,
+                description: learningGoal.description,
+                max_level: learningGoal.max_level
+            })
+            .eq("id", learningGoal.id);
+
+        if (error) {
+            throw error;
+        }
+    }
+
+    async deleteLearningGoal(learningGoalId: string): Promise<LearningGoalDTO[]> {
+        const {data, error} = await supabase
+            .from("learning_goals")
+            .delete()
+            .eq("id", learningGoalId)
+            .select();
+
+        if (error) throw error;
+
+        return data;
+    }
+}
+
+const LearningGoalsService = new LearningGoalsServiceClass();
+
+export default LearningGoalsService;

--- a/app/src/stores/learningGoals.ts
+++ b/app/src/stores/learningGoals.ts
@@ -1,0 +1,64 @@
+import {defineStore} from "pinia";
+import {useAuthStore} from "@/stores/auth.ts";
+import {LearningGoal} from "@/types/learningGoals.ts";
+import LearningGoalsService from "@/services/database/learningGoals.ts";
+
+interface LearningGoalsState {
+    learningGoals: LearningGoal[]
+    currentLearningGoal: LearningGoal | null
+}
+
+export const useLearningGoalsStore = defineStore('learningGoals', {
+    state: (): LearningGoalsState => ({
+        learningGoals: [],
+        currentLearningGoal: null
+    }),
+
+    getters: {
+        getCurrentLearningGoals: (state) => {
+            return state.learningGoals;
+        },
+        getCurrentLearningGoal: (state) => {
+            return state.currentLearningGoal;
+        }
+    },
+
+    actions: {
+
+        async fetchLearningGoals() {
+            const authStore = useAuthStore();
+            if (authStore.user && authStore.user.id) {
+                const data = await LearningGoalsService.pull.fetchLearningGoalsByUser(authStore.user.id)
+                if (data) this.learningGoals = data;
+                return data;
+            }
+        },
+
+        async updateCurrentLearningGoal(learningGoal: LearningGoal) {
+            await LearningGoalsService.push.updateLearningGoal(learningGoal);
+            this.currentLearningGoal = learningGoal;
+            const index = this.learningGoals.findIndex(goal => goal.id === learningGoal.id);
+            if (index >= 0) {
+                this.learningGoals[index] = this.currentLearningGoal;
+            }
+        },
+
+        async uploadLearningGoal(goal: LearningGoal) {
+            const authStore = useAuthStore();
+            if (authStore.user && authStore.user.id) {
+                const newGoal = await LearningGoalsService.push.uploadLearningGoal(goal, authStore.user.id);
+                if (newGoal) {
+                    this.learningGoals.push(newGoal);
+                }
+            }
+        },
+
+        async deleteLearningGoalById(id: string) {
+            await LearningGoalsService.push.deleteLearningGoal(id);
+            const index = this.learningGoals.findIndex(goal => goal.id === id);
+            if (index >= 0) {
+                this.learningGoals.splice(index, 1);
+            }
+        },
+    }
+});

--- a/app/src/types/learningGoals.ts
+++ b/app/src/types/learningGoals.ts
@@ -1,0 +1,10 @@
+import {Database} from "@/types/supabase.ts";
+
+export type LearningGoalDTO = Database["public"]["Tables"]["learning_goals"]["Row"];
+
+export type LearningGoal = {
+    id: string;
+    name: string;
+    description: string;
+    max_level: number;
+}

--- a/app/src/types/supabase.ts
+++ b/app/src/types/supabase.ts
@@ -38,6 +38,38 @@ export type Database = {
           },
         ]
       }
+      learning_goals: {
+        Row: {
+          description: string | null
+          id: string
+          max_level: number | null
+          name: string | null
+          user_id: string | null
+        }
+        Insert: {
+          description?: string | null
+          id?: string
+          max_level?: number | null
+          name?: string | null
+          user_id?: string | null
+        }
+        Update: {
+          description?: string | null
+          id?: string
+          max_level?: number | null
+          name?: string | null
+          user_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "learning_goals_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       lessons: {
         Row: {
           created_at: string

--- a/app/src/utils/dialogs.ts
+++ b/app/src/utils/dialogs.ts
@@ -135,5 +135,13 @@ export const DeleteProduct: DialogText = {
     cancelLabel: "Zurück"
 };
 
+export const DeleteLearningGoal: DialogText = {
+    title: "Lernziel löschen",
+    message: "Möchten Sie wirklich das ausgewählte Lernziel löschen? " +
+        "Dies kann nicht rückgängig gemacht werden und hat möglicherweise Auswirkungen auf bereits erstellte Lektionen und Level der Lernenden.",
+    confirmLabel: "Löschen",
+    cancelLabel: "Zurück"
+};
+
 
 

--- a/app/src/utils/validationRules.ts
+++ b/app/src/utils/validationRules.ts
@@ -20,6 +20,14 @@ export const requiredAtLeast6CharsRule = (value: string | null | any): boolean |
     return true;
 }
 
+export const maxLengthRule = (value: string | null | any): boolean | string => {
+    const maxLength = 200;
+    if (typeof value === 'string') {
+        return (value && value.length <= maxLength) || `Die Zeichenanzahl darf maximal ${maxLength} betragen.`;
+    }
+    return `Die Zeichenanzahl darf maximal ${maxLength} betragen.`;
+};
+
 export const minMaxWords = (value: string | null | any): boolean | string => {
 
     if (typeof value === 'string') {
@@ -52,6 +60,21 @@ export const requiredNumberRule = (value: null | number | string): boolean | str
         {
             const numericValue = parseFloat(value);
             return !isNaN(numericValue) ? true : 'Benötigt';
+        }
+    }
+};
+
+export const requiredPositiveNumberRule = (value: null | number | string): boolean | string => {
+    if (value === null || value === undefined || value === '') {
+        return 'Zahl muss größer als 0 sein';
+    }
+
+    if (typeof value === 'number') {
+        return !Number.isNaN(value) && value > 0 ? true : 'Zahl muss größer als 0 sein';
+    } else {
+        {
+            const numericValue = parseFloat(value);
+            return !isNaN(numericValue) && numericValue > 0 ? true : 'Zahl muss größer als 0 sein';
         }
     }
 };

--- a/app/src/views/learningGoals/LearningGoalsOverview.vue
+++ b/app/src/views/learningGoals/LearningGoalsOverview.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-row justify="space-between" align="center" class="mb-1">
+    <v-col cols="auto" class="text-h4">
+      Meine Lernziele ({{ learningGoalsStore.learningGoals.length }}/{{ MAX_LEARNING_GOALS }})
+    </v-col>
+    <v-col cols="auto">
+      <v-btn-group
+          elevation="3"
+          variant="outlined"
+          rounded
+          divided
+      >
+        <v-btn
+            @click="createLearningGoal"
+            :disabled="learningGoalsStore.learningGoals.length >= MAX_LEARNING_GOALS"
+        >
+          Neues Lernziel erstellen
+        </v-btn>
+      </v-btn-group>
+    </v-col>
+  </v-row>
+  <v-divider/>
+  <v-container>
+    <v-row>
+      <LearningGoalsTable/>
+    </v-row>
+  </v-container>
+  <EditLearningGoal v-if="editDialog" :dialog="editDialog" @update:dialog="updateEditDialog"></EditLearningGoal>
+</template>
+
+<script setup lang="ts">
+import {useAuthStore} from "@/stores/auth.ts";
+import {ref} from "vue";
+import LearningGoalsTable from "@/components/learningGoals/LearningGoalsTable.vue";
+import EditLearningGoal from "@/components/learningGoals/EditLearningGoal.vue";
+import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
+
+const MAX_LEARNING_GOALS = 5;
+const learningGoalsStore = useLearningGoalsStore();
+const authStore = useAuthStore();
+const editDialog = ref<boolean>(false);
+
+function updateEditDialog(value: boolean) {
+  editDialog.value = value;
+}
+
+async function createLearningGoal() {
+  if (authStore.user?.id) {
+    learningGoalsStore.currentLearningGoal = null;
+    editDialog.value = true;
+  }
+}
+</script>

--- a/supabase/database/policies/learningGoals.sql
+++ b/supabase/database/policies/learningGoals.sql
@@ -1,0 +1,53 @@
+-- Author: Laura
+
+--------------------------------------------
+-- Learning goals related policies
+--------------------------------------------
+
+DROP POLICY IF EXISTS "policy_learning_goals_select" ON public.learning_goals;
+CREATE POLICY "policy_learning_goals_select"
+    ON public.learning_goals
+    FOR SELECT
+    TO authenticated
+    USING (
+   (auth.uid() = user_id) OR
+    (get_teacher_uuid(auth.uid()) = user_id)
+    );
+
+    DROP POLICY IF EXISTS "policy_learning_goals_delete" ON public.learning_goals;
+    CREATE POLICY "policy_learning_goals_delete"
+        ON public.learning_goals
+        FOR DELETE
+        TO authenticated
+        USING (
+        (SELECT check_user_role(auth.uid(), 'moderator')) = true
+            OR
+        (auth.uid() = user_id AND (SELECT check_user_role(auth.uid(), 'teacher'))) = true
+        );
+
+    DROP POLICY IF EXISTS "policy_learning_goals_update" ON public.learning_goals;
+    CREATE POLICY "policy_learning_goals_update"
+        ON public.learning_goals
+        FOR UPDATE
+        TO authenticated
+        USING (
+        (SELECT check_user_role(auth.uid(), 'moderator')) = true
+            OR
+        (auth.uid() = user_id AND (SELECT check_user_role(auth.uid(), 'teacher'))) = true
+        );
+
+    DROP POLICY IF EXISTS "policy_learning_goals_insert" ON public.learning_goals;
+    CREATE POLICY "policy_learning_goals_insert"
+        ON public.learning_goals
+        FOR INSERT
+        TO authenticated
+        WITH CHECK (
+        (SELECT check_user_role(auth.uid(), 'moderator')) = true
+            OR
+        (auth.uid() = user_id AND (SELECT check_user_role(auth.uid(), 'teacher'))) = true AND (
+            EXISTS (SELECT COUNT(*)
+                    FROM public.learning_goals
+                    WHERE user_id = auth.uid()
+                    HAVING COUNT(*) < 5)
+            )
+        );


### PR DESCRIPTION
Lehrer können nun bis zu 5 Lernziele erstellen, bearbeiten, ansehen und löschen. Es wurde eine eigene Ansicht dafür erstellt nach ähnlichem Verfahren wie bei den Produkten und Anforderungen. 
Es wurden auch Policies erstellt, um die Zugriffe zu verwalten und nur 5 Lernziele erstellen zu dürfen. 
Die Lernziele können im nächsten Schritt mit Lektionen verknüpft werden, so dass dann Erfahrungspunkte für diese gesammelt werden können.