### PR TITLE
198 lernziele zu lektionen hinzufgen

### DIFF
--- a/app/src/components/lesson/builder/LessonBuilder.vue
+++ b/app/src/components/lesson/builder/LessonBuilder.vue
@@ -9,6 +9,7 @@ import {useLessonStore} from "@/stores/lesson.ts";
 import SortableModule from "@/components/lesson/builder/dragAndDrop/SortableModuleContainer.vue";
 import ModuleTarget from "@/components/lesson/builder/dragAndDrop/ModuleTarget.vue"
 import { ref } from "vue";
+import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
 
 const props = defineProps<{
   showToolTip: boolean
@@ -19,6 +20,7 @@ const templates = ['Requirement', 'TrueOrFalse', 'MultipleChoice', 'Textfield', 
 const lessonFormStore = useLessonFormStore();
 const lessonStore = useLessonStore();
 const utilStore = useUtilStore();
+const learningGoalStore = useLearningGoalsStore();
 
 const MAX_LESSONS: number = 20;
 const MAX_QUESTIONS: number = 20;
@@ -79,6 +81,22 @@ async function uploadLesson() {
               variant="outlined"
               v-model="lessonFormStore.lessonDescription"
           ></v-text-field>
+        </v-col>
+        <v-col>
+          <v-select
+              v-model="lessonFormStore.learningGoalId"
+              clearable
+              chips
+              :items="learningGoalStore.getCurrentLearningGoals"
+              density="comfortable"
+              label="Lernziel"
+              item-title="name"
+              item-value="id"
+              variant="outlined"
+              no-data-text="Es stehen noch keine Lernziele zur Verfügung."
+              :disabled="learningGoalStore.getCurrentLearningGoals.length < 0"
+          >
+          </v-select>
         </v-col>
       </v-row>
       <v-row no-gutters>

--- a/app/src/middlewares/learningGoals.ts
+++ b/app/src/middlewares/learningGoals.ts
@@ -1,10 +1,41 @@
-import { NavigationGuardNext, RouteLocationNormalized } from "vue-router";
+import {NavigationGuardNext, RouteLocationNormalized} from "vue-router";
 import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
+import {useLessonStore} from "@/stores/lesson.ts";
+import {useLessonFormStore} from "@/stores/lessonForm.ts";
+import {useAuthStore} from "@/stores/auth.ts";
 
 export async function fetchLearningGoalsByUser(to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) {
     try {
         const learningGoalsStore = useLearningGoalsStore();
         await learningGoalsStore.fetchLearningGoalsByUser();
+        return next();
+    } catch (error) {
+        return next({name: 'Error'});
+    }
+}
+
+export async function fetchLearningGoalsByLessonOwner(to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) {
+    try {
+        const lessonStore = useLessonStore();
+        const lessonFormStore = useLessonFormStore();
+        const authStore = useAuthStore();
+
+        const lessons = lessonStore.getLessons;
+        const lessonId = lessonFormStore.uuid;
+        const foundLesson = lessons.find(l => l.lessonDTO.uuid === lessonId);
+
+        if (authStore.user) {
+            let ownerId: string = authStore.user.id;
+
+            if (foundLesson) {
+                if (authStore.user.id !== foundLesson.lessonDTO.user_id) {
+                    ownerId = foundLesson.lessonDTO.user_id;
+                }
+            }
+            const learningGoalsStore = useLearningGoalsStore();
+            await learningGoalsStore.fetchLearningGoalsByUserId(ownerId);
+        }
+
         return next();
     } catch (error) {
         return next({name: 'Error'});

--- a/app/src/middlewares/learningGoals.ts
+++ b/app/src/middlewares/learningGoals.ts
@@ -4,7 +4,7 @@ import {useLearningGoalsStore} from "@/stores/learningGoals.ts";
 export async function fetchLearningGoalsByUser(to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) {
     try {
         const learningGoalsStore = useLearningGoalsStore();
-        await learningGoalsStore.fetchLearningGoals();
+        await learningGoalsStore.fetchLearningGoalsByUser();
         return next();
     } catch (error) {
         return next({name: 'Error'});

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -21,7 +21,7 @@ import {
 } from "@/middlewares/lesson.ts";
 import {useUtilStore} from "@/stores/util.ts";
 import {fetchProductsByUser} from "@/middlewares/product.ts";
-import {fetchLearningGoalsByUser} from "@/middlewares/learningGoals.ts";
+import {fetchLearningGoalsByLessonOwner, fetchLearningGoalsByUser} from "@/middlewares/learningGoals.ts";
 
 const routes = [
     {
@@ -55,8 +55,8 @@ const routes = [
                 meta: {
                     middleware: [
                         requiresTeacher,
-                        fetchLearningGoalsByUser,
-                        fetchLessons
+                        fetchLessons,
+                        fetchLearningGoalsByLessonOwner
                     ]
                 }
             },

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -55,6 +55,7 @@ const routes = [
                 meta: {
                     middleware: [
                         requiresTeacher,
+                        fetchLearningGoalsByUser,
                         fetchLessons
                     ]
                 }

--- a/app/src/services/database/learningGoals.ts
+++ b/app/src/services/database/learningGoals.ts
@@ -11,6 +11,8 @@ class LearningGoalsServiceClass {
 
     public pull = {
         fetchLearningGoalsByUser: this.fetchLearningGoalsByUser.bind(this),
+        fetchLearningGoalsByIds: this.fetchLearningGoalsByIds.bind(this),
+        fetchLearningGoals: this.fetchLearningGoals.bind(this)
     };
 
     private async fetchLearningGoalsByUser(userUUID: string): Promise<LearningGoal[] | undefined> {
@@ -25,6 +27,30 @@ class LearningGoalsServiceClass {
             return data as LearningGoal[];
         }
     }
+
+    private async fetchLearningGoals(): Promise<LearningGoal[] | undefined> {
+        const {data, error} = await supabase
+            .from("learning_goals")
+            .select("*")
+
+        if (error) throw error;
+
+        if (data) {
+            return data as LearningGoal[];
+        }
+    }
+
+    private async fetchLearningGoalsByIds(goalIds: string[]): Promise<LearningGoal[]> {
+        const {data, error} = await supabase
+            .from("learning_goals")
+            .select("*")
+            .in("id", goalIds);
+
+        if (error) throw error;
+
+        return data as LearningGoal[];
+    }
+
 
     private async uploadLearningGoal(learningGoal: LearningGoal, userUUID: string): Promise<LearningGoal | undefined> {
         const {data, error} = await supabase

--- a/app/src/stores/learningGoals.ts
+++ b/app/src/stores/learningGoals.ts
@@ -31,10 +31,16 @@ export const useLearningGoalsStore = defineStore('learningGoals', {
         async fetchLearningGoalsByUser() {
             const authStore = useAuthStore();
             if (authStore.user && authStore.user.id) {
-                const data = await LearningGoalsService.pull.fetchLearningGoalsByUser(authStore.user.id)
+                const data = await LearningGoalsService.pull.fetchLearningGoalsByUser(authStore.user.id);
                 if (data) this.learningGoals = data;
                 return data;
             }
+        },
+
+        async fetchLearningGoalsByUserId(userId: string) {
+            const data = await LearningGoalsService.pull.fetchLearningGoalsByUser(userId);
+            if (data) this.learningGoals = data;
+            return data;
         },
 
         async fetchLearningGoalsByIds(goalIds: string[]) {

--- a/app/src/stores/learningGoals.ts
+++ b/app/src/stores/learningGoals.ts
@@ -20,18 +20,25 @@ export const useLearningGoalsStore = defineStore('learningGoals', {
         },
         getCurrentLearningGoal: (state) => {
             return state.currentLearningGoal;
+        },
+        getLearningGoalById: (state) => (id: string) => {
+            return state.learningGoals.find(g => g.id === id);
         }
     },
 
     actions: {
 
-        async fetchLearningGoals() {
+        async fetchLearningGoalsByUser() {
             const authStore = useAuthStore();
             if (authStore.user && authStore.user.id) {
                 const data = await LearningGoalsService.pull.fetchLearningGoalsByUser(authStore.user.id)
                 if (data) this.learningGoals = data;
                 return data;
             }
+        },
+
+        async fetchLearningGoalsByIds(goalIds: string[]) {
+            return await LearningGoalsService.pull.fetchLearningGoalsByIds(goalIds);
         },
 
         async updateCurrentLearningGoal(learningGoal: LearningGoal) {

--- a/app/src/stores/lessonForm.ts
+++ b/app/src/stores/lessonForm.ts
@@ -12,6 +12,7 @@ interface LessonModuleEntry {
 interface LessonFormState {
     uuid: string;
     lessonTitle: string;
+    learningGoalId: string | null;
     lessonDescription: string;
     lessonModules: LessonModuleEntry[];
     insertModuleIndex: number;
@@ -22,6 +23,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
         uuid: uuidv4(),
         lessonModules: [],
         lessonTitle: '',
+        learningGoalId: null,
         lessonDescription: '',
         insertModuleIndex: 0,
     }),
@@ -98,6 +100,8 @@ export const useLessonFormStore = defineStore('lessonForm', {
             this.uuid = uuidv4();
             this.lessonTitle = '';
             this.lessonDescription = '';
+            this.learningGoalId = null;
+
             this.clearLessonModules();
         },
         generateLesson(): LessonForm {
@@ -105,6 +109,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
                 uuid: this.uuid,
                 title: this.lessonTitle,
                 description: this.lessonDescription,
+                learningGoalId: this.learningGoalId,
                 questions: this.lessonModules.map(component => {
                     return {
                         uuid: component.uuid,
@@ -124,6 +129,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
             this.uuid = lesson.uuid;
             this.lessonTitle = lesson.title;
             this.lessonDescription = lesson.description;
+            this.learningGoalId = lesson.learningGoalId;
             lesson.questions.forEach((question: Question) => {
                 this.lessonModules.push({
                     type: question.type || null,

--- a/app/src/types/lesson.ts
+++ b/app/src/types/lesson.ts
@@ -1,4 +1,5 @@
 import {Database} from "@/types/supabase.ts";
+import {LearningGoal} from "@/types/learningGoals.ts";
 
 export type LessonDTO = Database["public"]["Tables"]["lessons"]["Row"];
 export type QuestionDTO = Database["public"]["Tables"]["questions"]["Row"];
@@ -22,6 +23,7 @@ export type Lesson = {
     isStarted: boolean,
     hasSavedProgress: boolean,
     userScore: number,
+    learningGoal: LearningGoal | null
 
     creatorAvatar?: string,
     creatorUsername?: string,
@@ -32,6 +34,7 @@ export type LessonForm = {
     title: string;
     description: string;
     questions: Question[];
+    learningGoalId: string | null;
 }
 
 export type LessonAnswer = {

--- a/app/src/types/supabase.ts
+++ b/app/src/types/supabase.ts
@@ -75,6 +75,7 @@ export type Database = {
           created_at: string
           description: string
           example: boolean
+          learning_goal: string | null
           points: number | null
           published: boolean
           title: string
@@ -85,6 +86,7 @@ export type Database = {
           created_at?: string
           description: string
           example?: boolean
+          learning_goal?: string | null
           points?: number | null
           published?: boolean
           title: string
@@ -95,6 +97,7 @@ export type Database = {
           created_at?: string
           description?: string
           example?: boolean
+          learning_goal?: string | null
           points?: number | null
           published?: boolean
           title?: string
@@ -102,6 +105,13 @@ export type Database = {
           uuid?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "lessons_learning_goal_fkey"
+            columns: ["learning_goal"]
+            isOneToOne: false
+            referencedRelation: "learning_goals"
+            referencedColumns: ["id"]
+          },
           {
             foreignKeyName: "lessons_user_id_fkey"
             columns: ["user_id"]

--- a/app/src/views/lesson/LessonDetailsStudent.vue
+++ b/app/src/views/lesson/LessonDetailsStudent.vue
@@ -4,13 +4,13 @@ import alertService from "@/services/util/alert.ts";
 import AlertService from "@/services/util/alert.ts";
 import router from "@/router";
 import LessonQuestions from "@/components/lesson/generator/LessonQuestions.vue";
-import {LessonDTO} from "@/types/lesson.ts";
-import { ref } from "vue";
+import {Lesson} from "@/types/lesson.ts";
+import {ref} from "vue";
 import {supabase} from "@/plugins/supabase.ts";
 
 const lessonStore = useLessonStore();
 const sortedQuestions = lessonStore.getSortedCurrentQuestions;
-const currentLesson: LessonDTO | undefined = lessonStore.getCurrentLesson?.lessonDTO;
+const currentLesson: Lesson | null = lessonStore.getCurrentLesson;
 const isFinished = lessonStore.getCurrentLesson?.isFinished;
 const isStarted = lessonStore.getCurrentLesson?.isStarted;
 
@@ -27,16 +27,15 @@ defineExpose({
 async function submit() {
   const formIsValid = await checkValidity();
 
-  if (formIsValid && currentLesson) {
+  if (formIsValid && currentLesson?.lessonDTO) {
     let lessonJson = lessonStore.generateUserResults();
 
     if (lessonJson) {
       try {
-       const {data: data, error: error} = await supabase.functions.invoke('evaluate/lesson', {
-         body: lessonJson
-       });
-
-        await router.push({name: 'LessonResults', params: {lessonUUID: currentLesson.uuid}});
+        await supabase.functions.invoke('evaluate/lesson', {
+          body: lessonJson
+        });
+        await router.push({name: 'LessonResults', params: {lessonUUID: currentLesson.lessonDTO.uuid}});
       } catch (error: any) {
         AlertService.addErrorAlert("Fehler beim Abschicken der Daten: " + error.message);
       }
@@ -67,36 +66,48 @@ async function openDialog() {
 <template>
   <v-row justify="space-between" align="center">
     <v-col cols="auto" class="text-h4">
-      {{ currentLesson?.title }}
+      {{ currentLesson?.lessonDTO.title }}
+      <v-tooltip v-if="currentLesson?.learningGoal" location="left" :text="currentLesson?.learningGoal.description">
+        <template v-slot:activator="{ props }">
+          <v-chip v-bind="props"
+                  v-if="currentLesson.learningGoal"
+                  class="ma-5"
+                  prepend-icon="mdi-trophy"
+                  elevation="8"
+          >
+            {{ currentLesson.learningGoal.name }}
+          </v-chip>
+        </template>
+      </v-tooltip>
     </v-col>
     <v-col cols="auto" class="text-h4" align-self="center">
-      {{ currentLesson?.points }}
+      {{ currentLesson?.lessonDTO.points }}
       <v-icon class="mb-1" size="35" color="warning" :icon="'mdi-star-four-points-circle-outline'"></v-icon>
     </v-col>
   </v-row>
   <v-row align="center" no-gutters>
     <v-col cols="11" class="text-h5">
-      {{ sortedQuestions.length <= 0 ? 'Noch keine Fragen!' : currentLesson?.description }}
+      {{ sortedQuestions.length <= 0 ? 'Noch keine Fragen!' : currentLesson?.lessonDTO.description }}
     </v-col>
   </v-row>
   <v-divider/>
-    <v-form @submit.prevent ref="form">
-      <v-row no-gutters>
-        <v-col>
-          <LessonQuestions :components="lessonStore.getLessonModules"></LessonQuestions>
-        </v-col>
-      </v-row>
-      <v-row v-if="!isFinished || isStarted">
-        <v-col>
-          <v-container>
-            <v-btn :disabled="!isStarted && isFinished" type="button" class="mr-2"
-                   @click="saveProgress">Speichern
-            </v-btn>
-            <v-btn :disabled="!isStarted && isFinished" type="submit"
-                   @click="openDialog">Antworten abschicken
-            </v-btn>
-          </v-container>
-        </v-col>
-      </v-row>
-    </v-form>
+  <v-form @submit.prevent ref="form">
+    <v-row no-gutters>
+      <v-col>
+        <LessonQuestions :components="lessonStore.getLessonModules"></LessonQuestions>
+      </v-col>
+    </v-row>
+    <v-row v-if="!isFinished || isStarted">
+      <v-col>
+        <v-container>
+          <v-btn :disabled="!isStarted && isFinished" type="button" class="mr-2"
+                 @click="saveProgress">Speichern
+          </v-btn>
+          <v-btn :disabled="!isStarted && isFinished" type="submit"
+                 @click="openDialog">Antworten abschicken
+          </v-btn>
+        </v-container>
+      </v-col>
+    </v-row>
+  </v-form>
 </template>

--- a/app/src/views/lesson/LessonOverview.vue
+++ b/app/src/views/lesson/LessonOverview.vue
@@ -110,6 +110,18 @@
             </v-icon>
           </template>
           <template v-slot:append>
+            <v-tooltip v-if="lesson.learningGoal" location="left" :text="lesson.learningGoal.description">
+              <template v-slot:activator="{ props }">
+                <v-chip v-bind="props"
+                    v-if="lesson.learningGoal"
+                    class="mr-5 ma-5"
+                    prepend-icon="mdi-trophy"
+                    elevation="8"
+                >
+                  {{ lesson.learningGoal.name }}
+                </v-chip>
+              </template>
+            </v-tooltip>
             <v-chip
                 v-if="authStore.isModerator"
                 class="mr-10 ma-5"
@@ -183,7 +195,7 @@ import alertService from "@/services/util/alert.ts";
 import {Lesson, LessonDTO} from "@/types/lesson.ts";
 import LessonStatusStudent from "@/components/lesson/toolbar/LessonStatusStudent.vue";
 import {v4 as uuidv4} from "uuid";
-import { computed, ref } from "vue";
+import {computed, ref} from "vue";
 
 const lessonStore = useLessonStore();
 const lessonFormStore = useLessonFormStore();

--- a/app/src/views/lesson/LessonResults.vue
+++ b/app/src/views/lesson/LessonResults.vue
@@ -7,10 +7,10 @@ import LessonQuestions from "@/components/lesson/generator/LessonQuestions.vue";
 import AlertService from "@/services/util/alert.ts";
 import Feedback from "@/components/lesson/results/Feedback.vue";
 import Score from "@/components/lesson/results/Score.vue";
-import { onBeforeMount, ref } from "vue";
+import {onBeforeMount, ref} from "vue";
 
 const lessonStore = useLessonStore();
-const currentLesson = lessonStore.getCurrentLesson?.lessonDTO;
+const currentLesson = lessonStore.getCurrentLesson;
 const isFinished = lessonStore.getCurrentLesson?.isFinished;
 const profileStore = useProfileStore();
 
@@ -20,13 +20,13 @@ const newScore = ref<number>();
 
 onBeforeMount(async () => {
   const authStore = useAuthStore();
-  if (authStore.user && currentLesson) {
+  if (authStore.user && currentLesson?.lessonDTO) {
     try {
       await profileStore.fetchPoints(authStore.user.id);
-      const data = await lessonStore.checkLessonFinishedForFirstTime(currentLesson.uuid);
+      const data = await lessonStore.checkLessonFinishedForFirstTime(currentLesson.lessonDTO.uuid);
       if (data !== null && data !== undefined) finishedForFirstTime.value = data;
-      if(!finishedForFirstTime.value) {
-        newScore.value = await lessonStore.loadNewUserScoreForLesson(currentLesson.uuid);
+      if (!finishedForFirstTime.value) {
+        newScore.value = await lessonStore.loadNewUserScoreForLesson(currentLesson.lessonDTO.uuid);
       } else {
         newScore.value = userScore;
       }
@@ -41,16 +41,28 @@ onBeforeMount(async () => {
 
   <v-row justify="space-between" align="center">
     <v-col cols="10" class="text-h4">
-      {{ currentLesson?.title }}
+      {{ currentLesson?.lessonDTO.title }}
+      <v-tooltip v-if="currentLesson?.learningGoal" location="left" :text="currentLesson?.learningGoal.description">
+        <template v-slot:activator="{ props }">
+          <v-chip v-bind="props"
+                  v-if="currentLesson.learningGoal"
+                  class="ma-5"
+                  prepend-icon="mdi-trophy"
+                  elevation="8"
+          >
+            {{ currentLesson.learningGoal.name }}
+          </v-chip>
+        </template>
+      </v-tooltip>
     </v-col>
     <v-col cols="auto" class="text-h4" align-self="center">
-      {{ newScore }}/{{ currentLesson?.points }}
+      {{ newScore }}/{{ currentLesson?.lessonDTO.points }}
       <v-icon class="mb-1" size="35" color="warning" :icon="'mdi-star-four-points-circle-outline'"></v-icon>
     </v-col>
   </v-row>
   <v-row align="center" no-gutters>
     <v-col cols="11" class="text-h5">
-      {{ currentLesson?.description }}
+      {{ currentLesson?.lessonDTO.description }}
     </v-col>
   </v-row>
   <v-divider/>
@@ -71,12 +83,14 @@ onBeforeMount(async () => {
               <v-container>
                 <v-row class="mt-1" v-if="!finishedForFirstTime">
                   <v-col md="6" order="2" order-md="1" class="d-flex justify-center">
-                    <Score v-if="currentLesson && newScore !== undefined" :score="newScore" :show-icon="false"
-                           :max-score="currentLesson?.points ? currentLesson?.points : 0"></Score>
+                    <Score v-if="currentLesson?.lessonDTO && newScore !== undefined" :score="newScore"
+                           :show-icon="false"
+                           :max-score="currentLesson?.lessonDTO.points ? currentLesson?.lessonDTO.points : 0"></Score>
                   </v-col>
                   <v-col md="6" order="3" order-md="2" class="d-flex align-center justify-center">
-                    <Score v-if="currentLesson && userScore !== undefined" :score="userScore" :show-icon="true"
-                           :max-score="currentLesson?.points ? currentLesson?.points : 0"></Score>
+                    <Score v-if="currentLesson?.lessonDTO && userScore !== undefined" :score="userScore"
+                           :show-icon="true"
+                           :max-score="currentLesson?.lessonDTO.points ? currentLesson?.lessonDTO.points : 0"></Score>
                   </v-col>
                   <v-col md="6" order="1" order-md="3" class="text-h5 text-center">
                     Neue Punktzahl
@@ -88,8 +102,9 @@ onBeforeMount(async () => {
 
                 <v-row v-if="finishedForFirstTime">
                   <v-col class="d-flex align-center justify-center">
-                    <Score v-if="currentLesson && userScore !== undefined" :score="userScore" :show-icon="true"
-                           :max-score="currentLesson?.points ? currentLesson?.points : 0"></Score>
+                    <Score v-if="currentLesson?.lessonDTO && userScore !== undefined" :score="userScore"
+                           :show-icon="true"
+                           :max-score="currentLesson?.lessonDTO.points ? currentLesson?.lessonDTO.points : 0"></Score>
                   </v-col>
                   <v-col class="text-h5 text-center">
                     Erreichte Punkte

--- a/supabase/database/functions/lesson.sql
+++ b/supabase/database/functions/lesson.sql
@@ -7,18 +7,20 @@ $$
 DECLARE
     v_lesson_uuid uuid;
     question      jsonb;
-     total_points  int4 := 0;
+    total_points  int4 := 0;
 BEGIN
-    INSERT INTO lessons (uuid, title, description, user_id, published)
+    INSERT INTO lessons (uuid, title, description, user_id, published, learning_goal)
     VALUES ((data ->> 'uuid')::uuid,
             data ->> 'title',
             data ->> 'description',
             auth.uid(),
-            false)
+            false,
+            (data ->> 'learningGoalId')::uuid)
     ON CONFLICT (uuid) DO UPDATE
         SET title       = EXCLUDED.title,
             description = EXCLUDED.description,
-            user_id     = EXCLUDED.user_id
+            user_id     = EXCLUDED.user_id,
+            learning_goal = EXCLUDED.learning_goal
     RETURNING uuid INTO v_lesson_uuid;
 
 --Löscht alle Fragen, aus der Lesson. On conflict ist nun nutzlos, aber wurde mir zu umständlich, zu überprüfen, ob Fragen gelöscht wurden. FT
@@ -74,6 +76,7 @@ BEGIN
                    'uuid', l.uuid,
                    'title', l.title,
                    'description', l.description,
+                   'learningGoalId', l.learning_goal,
                    'questions', COALESCE(
                            jsonb_agg(
                                    jsonb_build_object(

--- a/supabase/database/policies/learningGoals.sql
+++ b/supabase/database/policies/learningGoals.sql
@@ -10,6 +10,7 @@ CREATE POLICY "policy_learning_goals_select"
     FOR SELECT
     TO authenticated
     USING (
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true OR
    (auth.uid() = user_id) OR
     (get_teacher_uuid(auth.uid()) = user_id)
     );


### PR DESCRIPTION
Man kann nun in der Lektionserstellung Lernziele auswählen, die dann zur Lektion gehören. Dies ist optional und man kann nur ein Lernziel wählen. 
Zur Auswahl erhält man nur die Lernziele, die einem selbst gehören oder dem Besitzer der Lektion, falls man z.B. Moderator ist. Dafür gibt es eine Middleware, die das prüft und die passenden Lernziele abruft.
Die Datenbankfunktionen get_lesson und create_lesson und der LessonFormStore wurden hierbei erweitert und angepasst für das Lernziel. 

Die Lernziele werden dann in den Lektionsübersichten und Details hervorgehoben. Die Ansicht lässt sich gegebenenfalls noch anpassen. Gibt es kein Lernziel, wird es einfach ausgeblendet/nicht angezeigt.

