### PR TITLE
211 erfahrungspunkte fr reqpal level erhalten

### DIFF
--- a/supabase/database/policies/activityLogs.sql
+++ b/supabase/database/policies/activityLogs.sql
@@ -1,0 +1,13 @@
+-- Author: Laura
+
+--------------------------------------------
+-- Xp Activity Logs related policies
+--------------------------------------------
+
+DROP POLICY IF EXISTS "policy_xp_activity_logs_levels" ON public.xp_activity_logs;
+CREATE POLICY "policy_user_levels"
+    ON public.xp_activity_logs
+    FOR ALL
+    TO authenticated
+    USING (
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true OR (auth.uid() = user_id));

--- a/supabase/database/policies/levels.sql
+++ b/supabase/database/policies/levels.sql
@@ -1,3 +1,9 @@
+-- Author: Laura
+
+--------------------------------------------
+-- User_Levels related policies
+--------------------------------------------
+
 DROP POLICY IF EXISTS "policy_user_levels_select" ON public.user_levels;
 CREATE POLICY "policy_user_levels_select"
     ON public.user_levels

--- a/supabase/database/policies/statistics.sql
+++ b/supabase/database/policies/statistics.sql
@@ -1,0 +1,22 @@
+-- Author: Laura
+
+--------------------------------------------
+-- User_Statistics related policies
+--------------------------------------------
+
+DROP POLICY IF EXISTS "policy_user_statistics_select" ON public.user_statistics;
+CREATE POLICY "policy_user_statistics_select"
+    ON public.user_statistics
+    FOR SELECT
+    TO authenticated
+    USING (
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true OR (SELECT check_user_role(auth.uid(), 'teacher')) OR
+    (auth.uid() = user_id));
+
+DROP POLICY IF EXISTS "policy_user_statistics" ON public.user_statistics;
+CREATE POLICY "policy_user_statistics"
+    ON public.user_statistics
+    FOR ALL
+    TO authenticated
+    USING (
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true OR (auth.uid() = user_id));

--- a/supabase/database/trigger/handler.sql
+++ b/supabase/database/trigger/handler.sql
@@ -7,8 +7,9 @@ create or replace function handle_new_user() returns trigger
 as
 $$
 DECLARE
-    user_role text;
+    user_role  text;
     teacher_id uuid := NULL;
+    xp INTEGER := 15;
 begin
     user_role := new.raw_user_meta_data ->> 'role';
 
@@ -28,13 +29,21 @@ begin
     perform set_claim(new.id, 'userroles', jsonb_build_array(user_role));
     perform update_user_permissions(new.id);
 
+    IF user_role = 'student' THEN
+        INSERT INTO user_statistics (user_id, total_xp)
+        VALUES (new.id, xp);
+
+        INSERT INTO xp_activity_logs (user_id, action, received_xp)
+        VALUES (new.id, 'Registrierung', xp);
+    end if;
+
     return new;
 end;
 $$;
 
-drop trigger if exists handle_new_user_trigger on auth.users;
-create trigger handle_new_user_trigger
+drop trigger if exists create_profile_trigger on auth.users;
+create trigger create_profile_trigger
     after insert
     on auth.users
     for each row
-execute procedure public.handle_new_user();
+    execute procedure public.handle_new_user();

--- a/supabase/database/trigger/levels.sql
+++ b/supabase/database/trigger/levels.sql
@@ -1,0 +1,90 @@
+-- Author: Laura
+
+--------------------------------------------
+-- React on newly gained xp on user_statistics
+-- update ReqPal level accordingly
+--------------------------------------------
+
+DROP TRIGGER IF EXISTS handle_user_statistics_insert_trigger ON user_statistics;
+DROP FUNCTION IF EXISTS update_reqpal_level();
+DROP FUNCTION IF EXISTS initiate_reqpal_level(UUID);
+DROP FUNCTION IF EXISTS calculate_threshold(INTEGER);
+
+CREATE OR REPLACE FUNCTION calculate_threshold(current_level INTEGER)
+    RETURNS INTEGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    base_xp INTEGER := 25;
+BEGIN
+    RETURN base_xp * (current_level + 1) * (current_level + 1);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION update_reqpal_level()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    new_xp               INTEGER;
+    reqpal_xp            INTEGER := 0;
+    current_xp_threshold INTEGER;
+    current_level        INTEGER;
+    user_exists          BOOLEAN;
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.total_xp IS DISTINCT FROM OLD.total_xp THEN
+
+        new_xp := NEW.total_xp - COALESCE(OLD.total_xp, 0);
+
+        IF (new_xp > 0) THEN
+
+            PERFORM 1
+            FROM user_reqpal_levels
+            WHERE user_id = NEW.user_id;
+
+            user_exists := FOUND;
+
+            IF NOT user_exists THEN
+                current_level := 0;
+                current_xp_threshold := calculate_threshold(current_level);
+                reqpal_xp := 0;
+
+                INSERT INTO user_reqpal_levels (user_id, xp, level, xp_threshold)
+                VALUES (NEW.user_id, reqpal_xp, current_level, current_xp_threshold);
+            ELSE
+                SELECT xp_threshold, level, xp
+                INTO current_xp_threshold, current_level, reqpal_xp
+                FROM user_reqpal_levels
+                WHERE user_id = NEW.user_id;
+            END IF;
+
+            new_xp := new_xp + reqpal_xp;
+
+            WHILE new_xp >= current_xp_threshold
+                LOOP
+                    current_level := current_level + 1;
+                    new_xp := new_xp - current_xp_threshold;
+                    current_xp_threshold := calculate_threshold(current_level);
+                END LOOP;
+
+            UPDATE user_reqpal_levels
+            SET xp           = new_xp,
+                level        = current_level,
+                xp_threshold = current_xp_threshold
+            WHERE user_id = NEW.user_id;
+
+        ELSE
+            RAISE LOG 'Negative XP-Änderung wird nicht behandelt: %', new_xp;
+        END IF;
+    END IF;
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER handle_user_statistics_insert_trigger
+    AFTER INSERT OR UPDATE
+    ON user_statistics
+    FOR EACH ROW
+EXECUTE FUNCTION update_reqpal_level();

--- a/supabase/database/trigger/statistics.sql
+++ b/supabase/database/trigger/statistics.sql
@@ -1,0 +1,60 @@
+-- Author: Laura
+
+--------------------------------------------
+-- Add newly gained xp to user_statistics
+-- on insert or update on user_levels
+--------------------------------------------
+
+DROP TRIGGER IF EXISTS handle_user_level_xp_trigger ON user_levels;
+
+CREATE OR REPLACE FUNCTION update_objective_statistics()
+    RETURNS TRIGGER
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    new_xp      INTEGER;
+    xp          INTEGER := 0;
+    user_exists BOOLEAN;
+BEGIN
+    IF TG_OP = 'INSERT' OR NEW.xp IS DISTINCT FROM OLD.xp THEN
+
+        new_xp := NEW.xp - COALESCE(OLD.xp, 0);
+
+        IF (new_xp > 0) THEN
+            PERFORM 1
+            FROM user_statistics
+            WHERE user_id = NEW.user_id;
+
+            user_exists := FOUND;
+
+            IF NOT user_exists THEN
+                INSERT INTO user_statistics (user_id, total_xp)
+                VALUES (NEW.user_id, new_xp);
+            ELSE
+                SELECT total_xp
+                INTO xp
+                FROM user_statistics
+                WHERE user_id = NEW.user_id;
+
+                new_xp := new_xp + xp;
+
+                UPDATE user_statistics
+                SET total_xp = new_xp
+                WHERE user_id = NEW.user_id;
+            END IF;
+        ELSE
+            RAISE LOG 'Negative XP-Änderung wird nicht behandelt: %', new_xp;
+        END IF;
+
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER handle_user_level_xp_trigger
+    AFTER INSERT OR UPDATE
+    ON user_levels
+    FOR EACH ROW
+EXECUTE FUNCTION update_objective_statistics();


### PR DESCRIPTION
Erfahrungspunkte und Level für das ReqPal Level werden nun über eine Datenbankfunktion verwaltet. Diese wird über einen Trigger aufgerufen, sobald der Nutzer Erfahrungspunkte innerhalb seiner Statistiken erhält.
So erhält der Nutzer aktuell Punkte und Updates zum Level sobald er sich registriert und wenn er Punkte für seine Lernziele erhält.

Wenn man für weitere Aktionen Xp erhalten soll, so kann man einfach die total_xp in der Statistik erhöhen. 
Es wurde zusätzlich ein Log eingeführt über die erhaltenen Xp und die dazugehörige Aktion, da dies vielleicht für die Benachrichtigungen im UI ganz nützlich sein könnte. 
Da diese Logs aber nicht dauerhaft benötigt werden, werden Logs, die älter als einen Tag sind, mithilfe eines Cron Jobs gelöscht.