### PR TITLE
225 achievements erstellen

### DIFF
--- a/app/src/components/achievement/AchievementTable.vue
+++ b/app/src/components/achievement/AchievementTable.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-data-table-virtual
+      class="mt-5"
+      v-model:expanded="expanded"
+      :headers="headers"
+      :items="achievementStore.getAchievements ? achievementStore.getAchievements : []"
+      item-value="id"
+      hover
+      height="70vh"
+      no-data-text="Sie haben noch keine Achievements erstellt."
+  >
+    <template v-slot:item.actions="{ item }">
+      <div>
+        <v-btn
+            class="ml-1"
+            density="compact"
+            color="success"
+            variant="plain"
+            size="medium"
+            icon="mdi-pencil"
+            @click.stop="openEditDialog(item)"
+        />
+        <v-btn
+            class="ml-2"
+            density="compact"
+            color="error"
+            variant="plain"
+            size="medium"
+            icon="mdi-delete"
+            @click.stop="deleteAchievement(item)"
+        />
+      </div>
+    </template>
+  </v-data-table-virtual>
+  <EditAchievement v-if="editDialog" :dialog="editDialog" @update:dialog="updateEditDialog"></EditAchievement>
+</template>
+
+<script setup lang="ts">
+import {ref} from "vue";
+import {DeleteAchievement} from "@/utils/dialogs.ts";
+import {useUtilStore} from "@/stores/util.ts";
+import {useAchievementStore} from "@/stores/achievement.ts";
+import {Achievement} from "@/types/achievement.ts";
+import EditAchievement from "@/components/achievement/EditAchievement.vue";
+
+const expanded = ref<any>([]);
+const utilStore = useUtilStore();
+const editDialog = ref<boolean>(false);
+
+const achievementStore = useAchievementStore();
+
+const headers = ref([
+  {title: "Titel", value: "title", sortable: true, width: "25%", align: "start"},
+  {title: "Beschreibung", value: "description", sortable: true, width: "auto", align: "center"},
+  {title: "Bild", value: "image", sortable: true, width: "auto", align: "center"},
+  {title: "Aktionen", value: "actions", sortable: false, width: "auto", align: "end"}
+] as const);
+
+function openEditDialog(item: Achievement | null) {
+  if (item) {
+    achievementStore.achievement = item;
+    editDialog.value = true;
+  }
+}
+
+function updateEditDialog(value: boolean) {
+  editDialog.value = value;
+}
+
+function deleteAchievement(item: Achievement) {
+  utilStore.openDialog(DeleteAchievement, () => {
+    achievementStore.deleteAchievement(item.id);
+  });
+}
+</script>

--- a/app/src/components/achievement/AchievementTable.vue
+++ b/app/src/components/achievement/AchievementTable.vue
@@ -9,6 +9,11 @@
       height="70vh"
       no-data-text="Sie haben noch keine Achievements erstellt."
   >
+    <template v-slot:item.image="{item}">
+      <div class="d-flex align-center justify-center">
+        <v-img max-width="50" :src="getAchievementImageUrl(item.image)" :alt="'Achievement Image: '+item.image"></v-img>
+      </div>
+    </template>
     <template v-slot:item.actions="{ item }">
       <div>
         <v-btn
@@ -42,6 +47,7 @@ import {useUtilStore} from "@/stores/util.ts";
 import {useAchievementStore} from "@/stores/achievement.ts";
 import {Achievement} from "@/types/achievement.ts";
 import EditAchievement from "@/components/achievement/EditAchievement.vue";
+import {getAchievementImageUrl} from "@/utils/achievementImage.ts";
 
 const expanded = ref<any>([]);
 const utilStore = useUtilStore();

--- a/app/src/components/achievement/EditAchievement.vue
+++ b/app/src/components/achievement/EditAchievement.vue
@@ -1,0 +1,107 @@
+<template>
+  <v-dialog
+      :model-value="dialog"
+      @update:model-value="close"
+      opacity="0.3"
+      max-width="900"
+  >
+    <v-form v-model="isFormValid" @submit.prevent="save" ref="form">
+      <v-card variant="elevated" class="pa-1">
+        <v-card-title v-if="localAchievement.id.length > 0">Achievement bearbeiten</v-card-title>
+        <v-card-title v-if="localAchievement.id.length <= 0">Achievement erstellen</v-card-title>
+        <v-card-text>
+          <v-row>
+            <v-col>
+              <div class="text-caption mb-2">
+                Achievement
+              </div>
+              <v-text-field variant="outlined" label="Titel" v-model="localAchievement.title"
+                            :rules="[requiredStringRule]"/>
+              <v-text-field variant="outlined" label="Beschreibung" v-model="localAchievement.description"
+                            :rules="[requiredStringRule, maxLengthRule]"/>
+              <v-text-field variant="outlined" label="Bild" v-model="localAchievement.image"
+                            :rules="[requiredStringRule]"/>
+            </v-col>
+          </v-row>
+        </v-card-text>
+        <v-card-actions>
+          <v-spacer></v-spacer>
+          <v-btn color="success" type="submit"
+                 :disabled="!isFormValid">Speichern
+          </v-btn>
+          <v-btn color="info" @click="close">Schließen</v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-form>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { onBeforeMount, ref } from "vue";
+import AlertService from "@/services/util/alert.ts";
+import {
+  maxLengthRule,
+  requiredStringRule
+} from "@/utils/validationRules.ts";
+import {useAchievementStore} from "@/stores/achievement.ts";
+import {Achievement} from "@/types/achievement.ts";
+
+interface Props {
+  dialog: boolean;
+}
+
+defineProps<Props>();
+const emit = defineEmits(["update:dialog"]);
+const achievementStore = useAchievementStore();
+const isFormValid = ref<boolean>(false);
+const localAchievement = ref<Achievement>({id: "", title: "", description: "", image: ""});
+const originalAchievement = ref<Achievement>();
+
+function close() {
+  emit("update:dialog", false);
+}
+
+async function save() {
+  if (originalAchievement.value && localAchievement.value) {
+    if (!areAchievementsEqual(originalAchievement.value, localAchievement.value)) {
+      await updateAchievement();
+    } else {
+      AlertService.addInfoAlert("Es wurden keine Änderungen vorgenommen.")
+      return;
+    }
+  } else if (!originalAchievement.value && localAchievement.value) {
+    await createAchievement();
+  }
+
+  emit("update:dialog", false);
+}
+
+async function updateAchievement() {
+  try {
+    await achievementStore.updateAchievement(localAchievement.value);
+    AlertService.addSuccessAlert("Achievement wurde aktualisiert.")
+  } catch (error: any) {
+    throw error;
+  }
+}
+
+async function createAchievement() {
+  try {
+    await achievementStore.uploadAchievement(localAchievement.value);
+    AlertService.addSuccessAlert("Achievement wurde erstellt.")
+  } catch (error: any) {
+    throw error;
+  }
+}
+
+function areAchievementsEqual(original: Achievement, edited: Achievement) {
+  return JSON.stringify(original) === JSON.stringify(edited);
+}
+
+onBeforeMount(async () => {
+  if (achievementStore.getAchievement) {
+    originalAchievement.value = achievementStore.getAchievement;
+    localAchievement.value = JSON.parse(JSON.stringify(originalAchievement.value));
+  }
+});
+</script>

--- a/app/src/components/achievement/EditAchievement.vue
+++ b/app/src/components/achievement/EditAchievement.vue
@@ -11,7 +11,7 @@
         <v-card-title v-if="localAchievement.id.length <= 0">Achievement erstellen</v-card-title>
         <v-card-text>
           <v-row>
-            <v-col>
+            <v-col sm="6">
               <div class="text-caption mb-2">
                 Achievement
               </div>
@@ -19,15 +19,46 @@
                             :rules="[requiredStringRule]"/>
               <v-text-field variant="outlined" label="Beschreibung" v-model="localAchievement.description"
                             :rules="[requiredStringRule, maxLengthRule]"/>
-              <v-text-field variant="outlined" label="Bild" v-model="localAchievement.image"
-                            :rules="[requiredStringRule]"/>
+            </v-col>
+            <v-col sm="6">
+              {{ localAchievement }}
+              <v-item-group label="Bild" v-model="localAchievement.image" :rules="requiredStringRule" mandatory>
+                <div class="text-caption mb-2">
+                  Wähle ein Bild
+                </div>
+                <v-container class="scroll-container">
+                  <v-row>
+                    <v-col
+                        v-for="image in achievementStore.images"
+                        :key="image"
+                        sm="6"
+                        md="4"
+                        class="d-flex justify-center"
+                    >
+                      <v-item :value="image" v-slot="{ toggle }">
+                        <v-card
+                            :color="localAchievement.image === image ? 'primary' : ''"
+                            variant="flat"
+                            class="d-flex align-center"
+                            width="100"
+                            @click="toggle"
+                        >
+                          <v-scroll-y-transition>
+                            <v-img :src="getAchievementImageUrl(image)" :alt="'Achievement Image: '+image"></v-img>
+                          </v-scroll-y-transition>
+                        </v-card>
+                      </v-item>
+                    </v-col>
+                  </v-row>
+                </v-container>
+              </v-item-group>
             </v-col>
           </v-row>
         </v-card-text>
         <v-card-actions>
           <v-spacer></v-spacer>
           <v-btn color="success" type="submit"
-                 :disabled="!isFormValid">Speichern
+                 :disabled="!isFormValid && (!localAchievement.image && localAchievement.image.length <= 0)">Speichern
           </v-btn>
           <v-btn color="info" @click="close">Schließen</v-btn>
         </v-card-actions>
@@ -37,7 +68,7 @@
 </template>
 
 <script setup lang="ts">
-import { onBeforeMount, ref } from "vue";
+import {onBeforeMount, ref} from "vue";
 import AlertService from "@/services/util/alert.ts";
 import {
   maxLengthRule,
@@ -45,6 +76,7 @@ import {
 } from "@/utils/validationRules.ts";
 import {useAchievementStore} from "@/stores/achievement.ts";
 import {Achievement} from "@/types/achievement.ts";
+import {getAchievementImageUrl} from "@/utils/achievementImage.ts";
 
 interface Props {
   dialog: boolean;
@@ -105,3 +137,10 @@ onBeforeMount(async () => {
   }
 });
 </script>
+
+<style scoped>
+.scroll-container {
+  max-height: 250px;
+  overflow-y: auto;
+}
+</style>

--- a/app/src/components/objectives/EditObjective.vue
+++ b/app/src/components/objectives/EditObjective.vue
@@ -7,8 +7,8 @@
   >
     <v-form v-model="isFormValid" @submit.prevent="save" ref="form">
       <v-card variant="elevated" class="pa-1">
-        <v-card-title v-if="localObjective.id.length > 0">Produkt bearbeiten</v-card-title>
-        <v-card-title v-if="localObjective.id.length <= 0">Produkt erstellen</v-card-title>
+        <v-card-title v-if="localObjective.id.length > 0">Lernziel bearbeiten</v-card-title>
+        <v-card-title v-if="localObjective.id.length <= 0">Lernziel erstellen</v-card-title>
         <v-card-text>
           <v-row>
             <v-col>

--- a/app/src/layouts/Default.vue
+++ b/app/src/layouts/Default.vue
@@ -83,6 +83,7 @@
           <v-list-item rounded prepend-icon="mdi-text-box-multiple" title="Meine Kataloge" to="/catalogs"/>
           <v-list-item rounded prepend-icon="mdi-invoice-list" title="Meine Produkte" to="/products"/>
           <v-list-item rounded prepend-icon="mdi-trophy" title="Meine Lernziele" to="/objectives"/>
+          <v-list-item rounded prepend-icon="mdi-trophy-award" title="Meine Achievements" to="/achievements"/>
           <v-list-item rounded prepend-icon="mdi-upload" title="Katalog Hochladen" to="/catalogs/upload"/>
           <v-divider class="my-1"/>
           <v-list-item rounded prepend-icon="mdi-school" title="Erstellte Lektionen"

--- a/app/src/middlewares/achievement.ts
+++ b/app/src/middlewares/achievement.ts
@@ -10,3 +10,13 @@ export async function fetchAchievementsByUser(to: RouteLocationNormalized, from:
         return next({name: 'Error'});
     }
 }
+
+export async function fetchAchievementImages(to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) {
+    try {
+        const achievementStore = useAchievementStore();
+        await achievementStore.fetchAchievementImages();
+        return next();
+    } catch (error) {
+        return next({name: 'Error'});
+    }
+}

--- a/app/src/middlewares/achievement.ts
+++ b/app/src/middlewares/achievement.ts
@@ -1,0 +1,12 @@
+import {NavigationGuardNext, RouteLocationNormalized} from "vue-router";
+import {useAchievementStore} from "@/stores/achievement.ts";
+
+export async function fetchAchievementsByUser(to: RouteLocationNormalized, from: RouteLocationNormalized, next: NavigationGuardNext) {
+    try {
+        const achievementStore = useAchievementStore();
+        await achievementStore.fetchAchievementsByUser();
+        return next();
+    } catch (error) {
+        return next({name: 'Error'});
+    }
+}

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -23,6 +23,7 @@ import {useUtilStore} from "@/stores/util.ts";
 import {fetchProductsByUser} from "@/middlewares/product.ts";
 import {fetchObjectivesByLessonOwner, fetchObjectivesByUser} from "@/middlewares/objective.ts";
 import {fetchObjectiveLevelsByUser, fetchReqPalLevelByUser} from "@/middlewares/level.ts";
+import {fetchAchievementsByUser} from "@/middlewares/achievement.ts";
 
 const routes = [
     {
@@ -150,6 +151,17 @@ const routes = [
                     middleware: [
                         requiresTeacher,
                         fetchObjectivesByUser
+                    ]
+                }
+            },
+            {
+                path: "/achievements",
+                name: "Achievements",
+                component: () => import("@/views/achievement/AchievementOverview.vue"),
+                meta: {
+                    middleware: [
+                        requiresTeacher,
+                        fetchAchievementsByUser
                     ]
                 }
             },

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -23,7 +23,7 @@ import {useUtilStore} from "@/stores/util.ts";
 import {fetchProductsByUser} from "@/middlewares/product.ts";
 import {fetchObjectivesByLessonOwner, fetchObjectivesByUser} from "@/middlewares/objective.ts";
 import {fetchObjectiveLevelsByUser, fetchReqPalLevelByUser} from "@/middlewares/level.ts";
-import {fetchAchievementsByUser} from "@/middlewares/achievement.ts";
+import {fetchAchievementImages, fetchAchievementsByUser} from "@/middlewares/achievement.ts";
 
 const routes = [
     {
@@ -161,7 +161,8 @@ const routes = [
                 meta: {
                     middleware: [
                         requiresTeacher,
-                        fetchAchievementsByUser
+                        fetchAchievementsByUser,
+                        fetchAchievementImages
                     ]
                 }
             },

--- a/app/src/services/database/achievement.ts
+++ b/app/src/services/database/achievement.ts
@@ -1,0 +1,81 @@
+import {supabase} from "@/plugins/supabase.ts";
+import {Achievement} from "@/types/achievement.ts";
+
+class AchievementServiceClass {
+
+    public push = {
+        uploadAchievement: this.uploadAchievement.bind(this),
+        updateAchievement: this.updateAchievement.bind(this),
+        deleteAchievement: this.deleteAchievement.bind(this)
+    };
+
+    public pull = {
+        fetchAchievementsByUser: this.fetchAchievementsByUser.bind(this)
+    }
+
+    private async fetchAchievementsByUser(userUUID: string): Promise<Achievement[] | undefined> {
+
+        const {data, error} = await supabase
+            .from('achievements')
+            .select('*')
+            .eq("user_id", userUUID);
+
+        if (error) throw error;
+
+        if (data) {
+            return data as Achievement[];
+        }
+    }
+
+    private async uploadAchievement(achievement: Achievement, userUUID: string): Promise<Achievement | undefined> {
+        const {data, error} = await supabase
+            .from('achievements')
+            .insert(
+                {
+                    user_id: userUUID,
+                    title: achievement.title,
+                    description: achievement.description,
+                    image: achievement.image,
+                }
+            )
+            .select()
+
+        if (error) throw error;
+
+        if(data && data.length > 0) {
+            return data[0] as Achievement;
+        }
+    }
+
+    private async updateAchievement(achievement: Achievement): Promise<void> {
+        if (!achievement.id) {
+            throw new Error("Achievement Id not found.")
+        }
+        const {error} = await supabase
+            .from("achievements")
+            .update({
+                title: achievement.title,
+                description: achievement.description,
+                image: achievement.image
+            })
+            .eq("id", achievement.id);
+
+        if (error) {
+            throw error;
+        }
+    }
+
+    async deleteAchievement(achievementId: string): Promise<void> {
+        const {data, error} = await supabase
+            .from("achievements")
+            .delete()
+            .eq("id", achievementId)
+            .select();
+
+        if (error) throw error;
+    }
+}
+
+const AchievementService = new AchievementServiceClass();
+
+export default AchievementService;

--- a/app/src/services/database/achievement.ts
+++ b/app/src/services/database/achievement.ts
@@ -1,5 +1,6 @@
 import {supabase} from "@/plugins/supabase.ts";
 import {Achievement} from "@/types/achievement.ts";
+import {createPathToImage} from "@/utils/achievementImage.ts";
 
 class AchievementServiceClass {
 
@@ -10,7 +11,9 @@ class AchievementServiceClass {
     };
 
     public pull = {
-        fetchAchievementsByUser: this.fetchAchievementsByUser.bind(this)
+        fetchAchievementsByUser: this.fetchAchievementsByUser.bind(this),
+        fetchAchievementImagesBadges: this.fetchAchievementImagesBadges.bind(this),
+        fetchAchievementImagesBanners: this.fetchAchievementImagesBanners.bind(this)
     }
 
     private async fetchAchievementsByUser(userUUID: string): Promise<Achievement[] | undefined> {
@@ -42,7 +45,7 @@ class AchievementServiceClass {
 
         if (error) throw error;
 
-        if(data && data.length > 0) {
+        if (data && data.length > 0) {
             return data[0] as Achievement;
         }
     }
@@ -73,6 +76,45 @@ class AchievementServiceClass {
             .select();
 
         if (error) throw error;
+    }
+
+    async fetchAchievementImagesBadges(): Promise<any> {
+        const {data, error} = await supabase
+            .storage
+            .from('achievement-images')
+            .list('badges', {
+                limit: 100,
+                offset: 0,
+                sortBy: {column: 'name', order: 'asc'},
+            })
+        if (error) throw error;
+        if (data) {
+            let images: string[] = [];
+            data.forEach(d => {
+                images.push(createPathToImage("badges", d.name));
+            })
+            return images;
+        }
+    }
+
+    async fetchAchievementImagesBanners(): Promise<any> {
+        const {data, error} = await supabase
+            .storage
+            .from('achievement-images')
+            .list('banners', {
+                limit: 100,
+                offset: 0,
+                sortBy: {column: 'name', order: 'asc'},
+            })
+        if (error) throw error;
+        if (data) {
+            let images: string[] = [];
+            data.forEach(d => {
+                if(d.name !== ".emptyFolderPlaceholder")
+                images.push(createPathToImage("banners", d.name));
+            })
+            return images;
+        }
     }
 }
 

--- a/app/src/services/database/objective.ts
+++ b/app/src/services/database/objective.ts
@@ -1,5 +1,5 @@
 import {supabase} from "@/plugins/supabase";
-import {Objective, ObjectiveDTO} from "@/types/objective.ts";
+import {Objective} from "@/types/objective.ts";
 
 class ObjectiveServiceClass {
 
@@ -88,16 +88,13 @@ class ObjectiveServiceClass {
         }
     }
 
-    async deleteObjective(objectiveId: string): Promise<ObjectiveDTO[]> {
+    async deleteObjective(objectiveId: string): Promise<void> {
         const {data, error} = await supabase
             .from("objectives")
             .delete()
             .eq("id", objectiveId)
-            .select();
 
         if (error) throw error;
-
-        return data;
     }
 }
 

--- a/app/src/stores/achievement.ts
+++ b/app/src/stores/achievement.ts
@@ -6,13 +6,15 @@ import AchievementService from "@/services/database/achievement.ts";
 
 interface AchievementState {
     achievement: Achievement | null,
-    achievements: Achievement[]
+    achievements: Achievement[],
+    images: string[]
 }
 
 export const useAchievementStore = defineStore('achievement', {
     state: (): AchievementState => ({
         achievement: null,
-        achievements: []
+        achievements: [],
+        images: []
     }),
 
     getters: {
@@ -38,6 +40,20 @@ export const useAchievementStore = defineStore('achievement', {
                 throw new AuthenticationError("No authorized user found.", 401)
             }
         },
+
+        async fetchAchievementImages(): Promise<void> {
+            const authStore = useAuthStore();
+
+            if (authStore.user) {
+                this.images = [];
+                const badges = await AchievementService.pull.fetchAchievementImagesBadges();
+                const banners = await AchievementService.pull.fetchAchievementImagesBanners();
+                this.images = [...badges, ...banners];
+            } else {
+                throw new AuthenticationError("No authorized user found.", 401)
+            }
+        },
+
         async uploadAchievement(achievement: Achievement) {
             const authStore = useAuthStore();
             if (authStore.user) {

--- a/app/src/stores/achievement.ts
+++ b/app/src/stores/achievement.ts
@@ -1,0 +1,68 @@
+import {defineStore} from "pinia";
+import {useAuthStore} from "@/stores/auth.ts";
+import {AuthenticationError} from "@/errors/custom.ts";
+import {Achievement} from "@/types/achievement.ts";
+import AchievementService from "@/services/database/achievement.ts";
+
+interface AchievementState {
+    achievement: Achievement | null,
+    achievements: Achievement[]
+}
+
+export const useAchievementStore = defineStore('achievement', {
+    state: (): AchievementState => ({
+        achievement: null,
+        achievements: []
+    }),
+
+    getters: {
+        getAchievement: (state) => {
+            return state.achievement;
+        },
+        getAchievements: (state) => {
+            return state.achievements;
+        }
+    },
+
+    actions: {
+        async fetchAchievementsByUser(): Promise<Achievement[] | undefined> {
+            const authStore = useAuthStore();
+
+            if (authStore.user) {
+                const data = await AchievementService.pull.fetchAchievementsByUser(authStore.user.id);
+                if (data && data.length > 0) {
+                    this.achievements = data;
+                    return data;
+                }
+            } else {
+                throw new AuthenticationError("No authorized user found.", 401)
+            }
+        },
+        async uploadAchievement(achievement: Achievement) {
+            const authStore = useAuthStore();
+            if (authStore.user) {
+                const newAchievement = await AchievementService.push.uploadAchievement(achievement, authStore.user.id);
+                if (newAchievement) {
+                    this.achievements.push(newAchievement);
+                }
+            }
+        },
+
+        async updateAchievement(achievement: Achievement) {
+            await AchievementService.push.updateAchievement(achievement);
+            this.achievement = achievement;
+            const index = this.achievements.findIndex(a => a.id === achievement.id);
+            if (index >= 0) {
+                this.achievements[index] = this.achievement;
+            }
+        },
+
+        async deleteAchievement(achievementId: string) {
+            await AchievementService.push.deleteAchievement(achievementId);
+            const index = this.achievements.findIndex(a => a.id === achievementId);
+            if (index >= 0) {
+                this.achievements.splice(index, 1);
+            }
+        }
+    }
+});

--- a/app/src/types/achievement.ts
+++ b/app/src/types/achievement.ts
@@ -1,0 +1,10 @@
+import {Database} from "@/types/supabase.ts";
+
+export type AchievementDTO = Database["public"]["Tables"]["achievements"]["Row"];
+
+export type Achievement = {
+    id: string;
+    title: string;
+    description: string;
+    image: string;
+}

--- a/app/src/types/supabase.ts
+++ b/app/src/types/supabase.ts
@@ -9,34 +9,34 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
-      bpmn_diagrams: {
+      achievements: {
         Row: {
+          created_at: string
+          description: string | null
           id: string
-          name: string | null
-          process_definition_key: string | null
-          user_id: string
-          version: number
-          xml_content: string | null
+          image: string | null
+          title: string | null
+          user_id: string | null
         }
         Insert: {
-          id: string
-          name?: string | null
-          process_definition_key?: string | null
-          user_id: string
-          version: number
-          xml_content?: string | null
+          created_at?: string
+          description?: string | null
+          id?: string
+          image?: string | null
+          title?: string | null
+          user_id?: string | null
         }
         Update: {
+          created_at?: string
+          description?: string | null
           id?: string
-          name?: string | null
-          process_definition_key?: string | null
-          user_id?: string
-          version?: number
-          xml_content?: string | null
+          image?: string | null
+          title?: string | null
+          user_id?: string | null
         }
         Relationships: [
           {
-            foreignKeyName: "bpmn_diagrams_user_id_fkey"
+            foreignKeyName: "achievements_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
@@ -66,6 +66,38 @@ export type Database = {
         Relationships: [
           {
             foreignKeyName: "catalogs_user_id_fkey"
+            columns: ["user_id"]
+            isOneToOne: false
+            referencedRelation: "profiles"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      diagrams: {
+        Row: {
+          id: string
+          name: string | null
+          process_definition_key: string | null
+          user_id: string
+          version: number
+        }
+        Insert: {
+          id: string
+          name?: string | null
+          process_definition_key?: string | null
+          user_id: string
+          version: number
+        }
+        Update: {
+          id?: string
+          name?: string | null
+          process_definition_key?: string | null
+          user_id?: string
+          version?: number
+        }
+        Relationships: [
+          {
+            foreignKeyName: "bpmn_diagrams_user_id_fkey"
             columns: ["user_id"]
             isOneToOne: false
             referencedRelation: "profiles"
@@ -440,7 +472,7 @@ export type Database = {
           deployed: boolean
           description: string | null
           diagram: string
-          id: number
+          id: string
           locked: boolean
           title: string
           user_id: string
@@ -450,7 +482,7 @@ export type Database = {
           deployed?: boolean
           description?: string | null
           diagram: string
-          id?: number
+          id?: string
           locked?: boolean
           title: string
           user_id: string
@@ -460,7 +492,7 @@ export type Database = {
           deployed?: boolean
           description?: string | null
           diagram?: string
-          id?: number
+          id?: string
           locked?: boolean
           title?: string
           user_id?: string
@@ -470,7 +502,7 @@ export type Database = {
             foreignKeyName: "scenarios_diagram_fkey"
             columns: ["diagram"]
             isOneToOne: false
-            referencedRelation: "bpmn_diagrams"
+            referencedRelation: "diagrams"
             referencedColumns: ["id"]
           },
           {

--- a/app/src/types/supabase.ts
+++ b/app/src/types/supabase.ts
@@ -73,38 +73,6 @@ export type Database = {
           },
         ]
       }
-      diagrams: {
-        Row: {
-          id: string
-          name: string | null
-          process_definition_key: string | null
-          user_id: string
-          version: number
-        }
-        Insert: {
-          id: string
-          name?: string | null
-          process_definition_key?: string | null
-          user_id: string
-          version: number
-        }
-        Update: {
-          id?: string
-          name?: string | null
-          process_definition_key?: string | null
-          user_id?: string
-          version?: number
-        }
-        Relationships: [
-          {
-            foreignKeyName: "bpmn_diagrams_user_id_fkey"
-            columns: ["user_id"]
-            isOneToOne: false
-            referencedRelation: "profiles"
-            referencedColumns: ["id"]
-          },
-        ]
-      }
       lessons: {
         Row: {
           created_at: string
@@ -468,43 +436,45 @@ export type Database = {
       }
       scenarios: {
         Row: {
+          bpmn_path: string | null
           created_at: string
           deployed: boolean
           description: string | null
-          diagram: string
           id: string
           locked: boolean
+          processDefinitionKey: string
+          svg_path: string | null
           title: string
           user_id: string
+          version: number
         }
         Insert: {
+          bpmn_path?: string | null
           created_at?: string
           deployed?: boolean
           description?: string | null
-          diagram: string
           id?: string
           locked?: boolean
+          processDefinitionKey: string
+          svg_path?: string | null
           title: string
           user_id: string
+          version?: number
         }
         Update: {
+          bpmn_path?: string | null
           created_at?: string
           deployed?: boolean
           description?: string | null
-          diagram?: string
           id?: string
           locked?: boolean
+          processDefinitionKey?: string
+          svg_path?: string | null
           title?: string
           user_id?: string
+          version?: number
         }
         Relationships: [
-          {
-            foreignKeyName: "scenarios_diagram_fkey"
-            columns: ["diagram"]
-            isOneToOne: false
-            referencedRelation: "diagrams"
-            referencedColumns: ["id"]
-          },
           {
             foreignKeyName: "scenarios_user_id_fkey"
             columns: ["user_id"]

--- a/app/src/utils/achievementImage.ts
+++ b/app/src/utils/achievementImage.ts
@@ -1,0 +1,8 @@
+export const createPathToImage = (folder: string, imageName: string): string => {
+    return "/" + folder + "/" + imageName;
+};
+
+export const getAchievementImageUrl = (path: string) => {
+    const url = "https://rouarbdbmlahwttlyspf.supabase.co/storage/v1/object/public/achievement-images";
+    return url + path;
+}

--- a/app/src/utils/dialogs.ts
+++ b/app/src/utils/dialogs.ts
@@ -143,5 +143,13 @@ export const DeleteObjective: DialogText = {
     cancelLabel: "Zurück"
 };
 
+export const DeleteAchievement: DialogText = {
+    title: "Achievement löschen",
+    message: "Möchten Sie wirklich das ausgewählte Achievement löschen? " +
+        "Dies kann nicht rückgängig gemacht werden und hat möglicherweise Auswirkungen auf bereits erstellte Szenarien und Achievements der Lernenden.",
+    confirmLabel: "Löschen",
+    cancelLabel: "Zurück"
+};
+
 
 

--- a/app/src/utils/validationRules.ts
+++ b/app/src/utils/validationRules.ts
@@ -11,6 +11,20 @@ export const requiredStringRule = (value: string | null | any): boolean | string
     return "Benötigt";
 }
 
+export const requiredSvgRule = (value: string | null | any): boolean | string => {
+    if (typeof value === 'string') {
+        const isNotEmpty = value && !!value.trim();
+        const startsWithSlash = value.startsWith('/');
+        const endsWithSvg = value.endsWith('.svg');
+
+        if (isNotEmpty && startsWithSlash && endsWithSvg) {
+            return true;
+        }
+        return "Muss mit '/' beginnen und mit '.svg' enden";
+    }
+    return "Benötigt";
+}
+
 export const requiredAtLeast6CharsRule = (value: string | null | any): boolean | string => {
     if (typeof value === 'string') {
         if (value.trim().length < 6) {

--- a/app/src/views/achievement/AchievementOverview.vue
+++ b/app/src/views/achievement/AchievementOverview.vue
@@ -1,0 +1,53 @@
+<template>
+  <v-row justify="space-between" align="center" class="mb-1">
+    <v-col cols="auto" class="text-h4">
+      Meine Achievements ({{ achievementStore.achievements.length }}/{{ MAX_ACHIEVEMENTS }})
+    </v-col>
+    <v-col cols="auto">
+      <v-btn-group
+          elevation="3"
+          variant="outlined"
+          rounded
+          divided
+      >
+        <v-btn
+            @click="createAchievement"
+            :disabled="achievementStore.achievements.length >= MAX_ACHIEVEMENTS"
+        >
+          Neues Achievement erstellen
+        </v-btn>
+      </v-btn-group>
+    </v-col>
+  </v-row>
+  <v-divider/>
+  <v-container>
+    <v-row>
+      <AchievementTable/>
+    </v-row>
+  </v-container>
+  <EditAchievement v-if="editDialog" :dialog="editDialog" @update:dialog="updateEditDialog"></EditAchievement>
+</template>
+
+<script setup lang="ts">
+import {useAuthStore} from "@/stores/auth.ts";
+import {ref} from "vue";
+import {useAchievementStore} from "@/stores/achievement.ts";
+import AchievementTable from "@/components/achievement/AchievementTable.vue";
+import EditAchievement from "@/components/achievement/EditAchievement.vue";
+
+const MAX_ACHIEVEMENTS = 20;
+const achievementStore = useAchievementStore();
+const authStore = useAuthStore();
+const editDialog = ref<boolean>(false);
+
+function updateEditDialog(value: boolean) {
+  editDialog.value = value;
+}
+
+async function createAchievement() {
+  if (authStore.user?.id) {
+    achievementStore.achievement = null;
+    editDialog.value = true;
+  }
+}
+</script>

--- a/supabase/database/policies/achievements.sql
+++ b/supabase/database/policies/achievements.sql
@@ -1,0 +1,23 @@
+-- Author: Laura
+
+--------------------------------------------
+-- Achievement related policies
+--------------------------------------------
+
+DROP POLICY IF EXISTS "policy_achievements" ON public.achievements;
+CREATE POLICY "policy_achievements"
+    ON public.achievements
+    FOR ALL
+    TO authenticated
+    USING (
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true
+        OR (auth.uid() = user_id AND (SELECT check_user_role(auth.uid(), 'teacher'))) = true);
+
+DROP POLICY IF EXISTS "policy_achievements_select" ON public.achievements;
+CREATE POLICY "policy_achievements_select"
+    ON public.achievements
+    FOR SELECT
+    TO authenticated
+    USING (
+    get_teacher_uuid(auth.uid()) = user_id
+    );

--- a/supabase/database/trigger/achievements.sql
+++ b/supabase/database/trigger/achievements.sql
@@ -1,0 +1,26 @@
+-- Author: Laura
+
+create or replace function check_max_achievements() returns trigger
+    language plpgsql
+as
+$$
+DECLARE
+    maxEntries INT := 20;
+    currentCount INT;
+BEGIN
+    SELECT COUNT(*) INTO currentCount FROM achievements WHERE user_id = NEW.user_id;
+
+    IF currentCount >= maxEntries THEN
+        RAISE EXCEPTION 'Maximale Anzahl an Achievements für diesen Nutzer erreicht';
+    END IF;
+
+    RETURN NEW;
+END;
+$$;
+
+drop trigger if exists check_max_achievements_trigger on achievements;
+create trigger check_max_achievements_trigger
+    before insert
+    on achievements
+    for each row
+execute procedure check_max_achievements();


### PR DESCRIPTION
Dozenten können nun erstellte Achievements betrachten innerhalb einer Tabelle, ähnlich wie bei Katalogen usw. auch. Sie können Achievements bearbeiten, löschen und erstellen. Sie können aus vordefinierten Bildern (Svgs) auswählen. 
Ein Trigger prüft, ob die maximale Anzahl pro Nutzer erreicht wurde bei neuen Achievements.

