### PR TITLE
232 lektionen knnen mehrere lernziele haben

### DIFF
--- a/app/src/components/lesson/LessonTable.vue
+++ b/app/src/components/lesson/LessonTable.vue
@@ -2,7 +2,7 @@
   <v-data-table-virtual
       :v-model="lessonStore.getLessons"
       v-model:expanded="expanded"
-      :headers="headers"
+      :headers="authStore.isModerator ? headersModerator : headers"
       :items="filters.includes('showOnlyOwn') ? filteredLessons : lessons"
       item-value="lessonDTO.uuid"
       select-strategy="all"
@@ -13,6 +13,15 @@
       height="75vh"
       no-data-text="Sie haben noch keine Lektionen erstellt."
   >
+    <template v-slot:item.creatorUsername="{ item }">
+      <v-chip
+          :prepend-avatar="'avatars/' + item.creatorAvatar + '.png'"
+          elevation="8"
+      >
+        {{ item.creatorUsername }}
+      </v-chip>
+    </template>
+
     <template v-slot:item.actions="{ item }">
       <div>
         <v-btn
@@ -117,6 +126,14 @@ const headers = ref([
   {title: "Titel", value: "lessonDTO.title", sortable: true, width: "25%", align: "start"},
   {title: "Beschreibung", value: "lessonDTO.description", sortable: true, width: "auto", align: "center"},
   {title: "Punkte", value: "lessonDTO.points", sortable: true, width: "auto", align: "center"},
+  {title: "Aktionen", value: "actions", sortable: false, width: "auto", align: "end"}
+] as const);
+
+const headersModerator = ref([
+  {title: "Titel", value: "lessonDTO.title", sortable: true, width: "25%", align: "start"},
+  {title: "Beschreibung", value: "lessonDTO.description", sortable: true, width: "auto", align: "center"},
+  {title: "Punkte", value: "lessonDTO.points", sortable: true, width: "auto", align: "center"},
+  {title: "Besitzer", value: "creatorUsername", sortable: true, width: "auto", align: "center"},
   {title: "Aktionen", value: "actions", sortable: false, width: "auto", align: "end"}
 ] as const);
 

--- a/app/src/components/lesson/LessonTable.vue
+++ b/app/src/components/lesson/LessonTable.vue
@@ -54,18 +54,38 @@
       </div>
     </template>
     <template v-slot:expanded-row="{ columns, item }">
-      <tr v-if="item.objective">
+      <tr v-if="item.objectives.length > 0">
         <td :colspan="columns.length">
-          <ol class="ml-5">
-            <li>{{ item.objective.name }}</li>
-          </ol>
+          <v-list>
+            <v-list-subheader>Lernziele</v-list-subheader>
+
+            <v-list-item
+                v-for="(objective, i) in item.objectives"
+                :key="i"
+                :value="objective"
+                color="primary"
+                variant="plain"
+            >
+              <template v-slot:prepend>
+                <v-icon icon="mdi-trophy"></v-icon>
+              </template>
+
+              <v-list-item-title v-text="objective.name"></v-list-item-title>
+            </v-list-item>
+          </v-list>
         </td>
       </tr>
       <tr v-else>
         <td :colspan="columns.length">
-          <ul class="ml-5">
-            <li>Noch keine Lernziele zur Lektion hinzugefügt.</li>
-          </ul>
+          <v-list>
+            <v-list-subheader>Lernziele</v-list-subheader>
+            <v-list-item
+                color="primary"
+                variant="plain"
+            >
+              <v-list-item-title v-text="'Noch keine Lernziele zur Lektion hinzugefügt'"></v-list-item-title>
+            </v-list-item>
+          </v-list>
         </td>
       </tr>
     </template>

--- a/app/src/components/lesson/builder/LessonBuilder.vue
+++ b/app/src/components/lesson/builder/LessonBuilder.vue
@@ -84,8 +84,9 @@ async function uploadLesson() {
         </v-col>
         <v-col>
           <v-select
-              v-model="lessonFormStore.objectiveId"
+              v-model="lessonFormStore.objectiveIds"
               clearable
+              multiple
               chips
               :items="objectiveStore.getCurrentObjectives"
               density="comfortable"

--- a/app/src/mapper/lesson.ts
+++ b/app/src/mapper/lesson.ts
@@ -1,0 +1,26 @@
+import {ObjectiveDTO} from "@/types/objective.ts";
+import {Lesson, LessonDTO} from "@/types/lesson.ts";
+
+export const mapToLesson = (input: any): Lesson => {
+    const objectives: ObjectiveDTO[] = [];
+
+    input.lesson_objectives.forEach((lessonObjective: any) => {
+        objectives.push(lessonObjective.objectives);
+    });
+
+    const lessonDto: LessonDTO = {
+        description: input.description,
+        title: input.title,
+        points: input.points,
+        created_at: input.created_at,
+        uuid: input.uuid,
+        published: input.published,
+        user_id: input.user_id,
+        example: input.example
+    }
+
+    return {
+        lessonDTO: lessonDto,
+        objectives: objectives
+    };
+};

--- a/app/src/stores/lesson.ts
+++ b/app/src/stores/lesson.ts
@@ -1,11 +1,9 @@
 import {defineStore} from 'pinia';
-import {Lesson, LessonDTO, Question, UserAnswer} from "@/types/lesson.ts";
+import {Lesson, LessonDTO, Question} from "@/types/lesson.ts";
 import lessonService from "@/services/database/lesson.ts";
 import LessonService from "@/services/database/lesson.ts";
 import {DatabaseError} from "@/errors/custom.ts";
 import {useAuthStore} from "@/stores/auth.ts";
-import profileService from "@/services/database/profile.ts";
-import {useObjectiveStore} from "@/stores/objective.ts";
 
 interface LessonState {
     examples: Lesson[],
@@ -68,54 +66,9 @@ export const useLessonStore = defineStore('lesson', {
 
         async fetchLessons() {
             const lessons = await lessonService.pull.fetchLessons();
-            this.lessons = [];
-            this.examples = [];
-
-            if (lessons) {
-                const enrichedLessons = [];
-
-                for (const lesson of lessons) {
-                    const creatorUsername = await profileService.pull.getUsername(lesson.user_id) || {username: 'Unbekannt'};
-                    const creatorAvatar = await profileService.pull.getAvatar(lesson.user_id) || {avatar: 'fhdo'};
-
-                    enrichedLessons.push({
-                        lessonDTO: lesson,
-                        objective: null,
-                        creatorUsername: creatorUsername.username,
-                        creatorAvatar: creatorAvatar.avatar
-                    });
-                }
-
-                this.lessons = enrichedLessons;
-            }
-
             const exampleLessons = await lessonService.pull.fetchLessons(true);
-
-            if (exampleLessons) {
-                this.examples = exampleLessons.map((l) => ({
-                    lessonDTO: l,
-                    objective: null
-                }));
-            }
-            await this.initLessons(this.lessons);
-            await this.initLessons(this.examples);
-        },
-
-        async initLessons(lessons: Lesson[]) {
-            const objectiveIds = lessons
-                .map(lesson => lesson.lessonDTO.objective)
-                .filter(objective => objective !== undefined && objective !== null);
-
-            if (objectiveIds.length > 0) {
-                const objectiveStore = useObjectiveStore();
-                const objectives = await objectiveStore.fetchObjectivesByIds(objectiveIds);
-                if (objectives) {
-                    lessons.forEach(l => {
-                        const toAdd = objectives.find(g => g.id === l.lessonDTO.objective);
-                        if (toAdd) l.objective = toAdd;
-                    })
-                }
-            }
+            this.lessons = lessons ? lessons : [];
+            this.examples = exampleLessons ? exampleLessons : [];
         },
 
         async deleteLesson(lessonUUID: string) {
@@ -200,14 +153,6 @@ export const useLessonStore = defineStore('lesson', {
                     })
                 })
             }
-        },
-
-        hydrateUserAnswers(answers: UserAnswer[]) {
-            answers.forEach(answer => {
-                const comp =
-                    this.lessonModules.find(c => c.uuid === answer.question_id);
-                if (comp) comp.data.options = answer.answer;
-            });
         },
 
         findLesson(lessonUUID: string) {

--- a/app/src/stores/lesson.ts
+++ b/app/src/stores/lesson.ts
@@ -4,6 +4,7 @@ import lessonService from "@/services/database/lesson.ts";
 import LessonService from "@/services/database/lesson.ts";
 import {DatabaseError} from "@/errors/custom.ts";
 import {useAuthStore} from "@/stores/auth.ts";
+import profileService from "@/services/database/profile.ts";
 
 interface LessonState {
     examples: Lesson[],
@@ -67,6 +68,17 @@ export const useLessonStore = defineStore('lesson', {
         async fetchLessons() {
             const lessons = await lessonService.pull.fetchLessons();
             const exampleLessons = await lessonService.pull.fetchLessons(true);
+
+            if (lessons) {
+                for (const lesson of lessons) {
+                    const creatorUsername = await profileService.pull.getUsername(lesson.lessonDTO.user_id) || {username: 'Unbekannt'};
+                    const creatorAvatar = await profileService.pull.getAvatar(lesson.lessonDTO.user_id) || {avatar: 'fhdo'};
+
+                    lesson.creatorAvatar = creatorAvatar.avatar;
+                    lesson.creatorUsername = creatorUsername.username;
+                }
+            }
+
             this.lessons = lessons ? lessons : [];
             this.examples = exampleLessons ? exampleLessons : [];
         },

--- a/app/src/stores/lessonForm.ts
+++ b/app/src/stores/lessonForm.ts
@@ -12,7 +12,7 @@ interface LessonModuleEntry {
 interface LessonFormState {
     uuid: string;
     lessonTitle: string;
-    objectiveId: string | null;
+    objectiveIds: string[];
     lessonDescription: string;
     lessonModules: LessonModuleEntry[];
     insertModuleIndex: number;
@@ -23,7 +23,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
         uuid: uuidv4(),
         lessonModules: [],
         lessonTitle: '',
-        objectiveId: null,
+        objectiveIds: [],
         lessonDescription: '',
         insertModuleIndex: 0,
     }),
@@ -100,7 +100,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
             this.uuid = uuidv4();
             this.lessonTitle = '';
             this.lessonDescription = '';
-            this.objectiveId = null;
+            this.objectiveIds = [];
 
             this.clearLessonModules();
         },
@@ -109,7 +109,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
                 uuid: this.uuid,
                 title: this.lessonTitle,
                 description: this.lessonDescription,
-                objectiveId: this.objectiveId,
+                objectiveIds: this.objectiveIds,
                 questions: this.lessonModules.map(component => {
                     return {
                         uuid: component.uuid,
@@ -129,7 +129,7 @@ export const useLessonFormStore = defineStore('lessonForm', {
             this.uuid = lesson.uuid;
             this.lessonTitle = lesson.title;
             this.lessonDescription = lesson.description;
-            this.objectiveId = lesson.objectiveId;
+            this.objectiveIds = lesson.objectiveIds;
             lesson.questions.forEach((question: Question) => {
                 this.lessonModules.push({
                     type: question.type || null,

--- a/app/src/types/lesson.ts
+++ b/app/src/types/lesson.ts
@@ -1,5 +1,5 @@
 import {Database} from "@/types/supabase.ts";
-import {Objective} from "@/types/objective.ts";
+import {ObjectiveDTO} from "@/types/objective.ts";
 
 export type LessonDTO = Database["public"]["Tables"]["lessons"]["Row"];
 export type QuestionDTO = Database["public"]["Tables"]["questions"]["Row"];
@@ -19,7 +19,7 @@ export type Question = {
 
 export type Lesson = {
     lessonDTO: LessonDTO,
-    objective: Objective | null
+    objectives: ObjectiveDTO[],
 
     creatorAvatar?: string,
     creatorUsername?: string,
@@ -30,7 +30,7 @@ export type LessonForm = {
     title: string;
     description: string;
     questions: Question[];
-    objectiveId: string | null;
+    objectiveIds: string[];
 }
 
 export type UserAnswer = {

--- a/app/src/types/supabase.ts
+++ b/app/src/types/supabase.ts
@@ -73,6 +73,39 @@ export type Database = {
           },
         ]
       }
+      lesson_objectives: {
+        Row: {
+          id: string
+          lesson_id: string | null
+          objective_id: string | null
+        }
+        Insert: {
+          id?: string
+          lesson_id?: string | null
+          objective_id?: string | null
+        }
+        Update: {
+          id?: string
+          lesson_id?: string | null
+          objective_id?: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "lesson_objectives_lesson_id_fkey"
+            columns: ["lesson_id"]
+            isOneToOne: false
+            referencedRelation: "lessons"
+            referencedColumns: ["uuid"]
+          },
+          {
+            foreignKeyName: "lesson_objectives_objective_id_fkey"
+            columns: ["objective_id"]
+            isOneToOne: false
+            referencedRelation: "objectives"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
       lessons: {
         Row: {
           created_at: string

--- a/app/src/types/supabase.ts
+++ b/app/src/types/supabase.ts
@@ -111,7 +111,6 @@ export type Database = {
           created_at: string
           description: string
           example: boolean
-          objective: string | null
           points: number | null
           published: boolean
           title: string
@@ -122,7 +121,6 @@ export type Database = {
           created_at?: string
           description: string
           example?: boolean
-          objective?: string | null
           points?: number | null
           published?: boolean
           title: string
@@ -133,7 +131,6 @@ export type Database = {
           created_at?: string
           description?: string
           example?: boolean
-          objective?: string | null
           points?: number | null
           published?: boolean
           title?: string
@@ -141,13 +138,6 @@ export type Database = {
           uuid?: string
         }
         Relationships: [
-          {
-            foreignKeyName: "lessons_objective_fkey"
-            columns: ["objective"]
-            isOneToOne: false
-            referencedRelation: "objectives"
-            referencedColumns: ["id"]
-          },
           {
             foreignKeyName: "lessons_user_id_fkey"
             columns: ["user_id"]

--- a/app/src/views/lesson/LessonDetailsTeacher.vue
+++ b/app/src/views/lesson/LessonDetailsTeacher.vue
@@ -4,18 +4,6 @@
       {{ currentLesson?.lessonDTO.title }} -
       {{ currentLesson?.lessonDTO.points }}
       <v-icon class="mb-1" size="35" color="warning" :icon="'mdi-star-four-points-circle-outline'"></v-icon>
-      <v-tooltip v-if="currentLesson?.objective" location="right" :text="currentLesson.objective.description">
-        <template v-slot:activator="{ props }">
-          <v-chip v-bind="props"
-                  v-if="currentLesson.objective"
-                  class="ma-5"
-                  prepend-icon="mdi-trophy"
-                  elevation="8"
-          >
-            {{ currentLesson.objective.name }}
-          </v-chip>
-        </template>
-      </v-tooltip>
     </v-col>
     <v-col cols="auto">
       <v-btn-toggle
@@ -34,6 +22,24 @@
           {{ filters.includes('showSolutions') ? 'Vorschau anzeigen' : 'Lösungen anzeigen' }}
         </v-btn>
       </v-btn-toggle>
+    </v-col>
+  </v-row>
+  <v-row>
+    <v-col cols="auto" class="d-flex justify-start align-center flex-wrap">
+      <div v-for="objective in currentLesson?.objectives" v-if="currentLesson && currentLesson.objectives?.length > 0">
+        <v-tooltip location="top" v-if="objective.description" :text="objective.description">
+          <template v-slot:activator="{ props }">
+            <v-chip
+                v-bind="props"
+                class="ma-5"
+                prepend-icon="mdi-trophy"
+                elevation="8"
+            >
+              {{ objective.name }}
+            </v-chip>
+          </template>
+        </v-tooltip>
+      </div>
     </v-col>
   </v-row>
   <v-row align="center" no-gutters>
@@ -91,10 +97,10 @@ import {LessonModuleEntry, useLessonStore} from "@/stores/lesson.ts";
 import LessonQuestions from "@/components/lesson/generator/LessonQuestions.vue";
 import {Lesson, LessonStatistic} from "@/types/lesson.ts";
 import Score from "@/components/lesson/results/Score.vue";
-import { ref, watch } from "vue";
+import {ref, watch} from "vue";
 
 const lessonStore = useLessonStore();
-const currentLesson : Lesson | null = lessonStore.getCurrentLesson;
+const currentLesson: Lesson | null = lessonStore.getCurrentLesson;
 
 const avgScore = ref<number>(0);
 const stats = ref<any>();

--- a/bpmn-server/src/main/java/inc/plab/bpmn/model/lesson/Lesson.java
+++ b/bpmn-server/src/main/java/inc/plab/bpmn/model/lesson/Lesson.java
@@ -1,6 +1,5 @@
 package inc.plab.bpmn.model.lesson;
 
-import inc.plab.bpmn.model.objective.Objective;
 import inc.plab.bpmn.model.question.Question;
 import inc.plab.bpmn.model.user.*;
 import jakarta.persistence.*;
@@ -23,6 +22,7 @@ import java.util.UUID;
 public class Lesson {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
+    @ColumnDefault("uuid_generate_v4()")
     @Column(name = "uuid", nullable = false)
     private UUID id;
 
@@ -58,10 +58,8 @@ public class Lesson {
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
-    @JoinColumn(name = "objective")
-    private Objective objective;
+    @OneToMany(mappedBy = "lesson")
+    private Set<LessonObjective> lessonObjectives = new LinkedHashSet<>();
 
     @OneToMany(mappedBy = "lessonUuid")
     private Set<Question> questions = new LinkedHashSet<>();

--- a/bpmn-server/src/main/java/inc/plab/bpmn/model/lesson/LessonObjective.java
+++ b/bpmn-server/src/main/java/inc/plab/bpmn/model/lesson/LessonObjective.java
@@ -1,0 +1,34 @@
+package inc.plab.bpmn.model.lesson;
+
+import inc.plab.bpmn.model.objective.Objective;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.util.UUID;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "lesson_objectives")
+public class LessonObjective {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @ColumnDefault("uuid_generate_v4()")
+    @Column(name = "id", nullable = false)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "lesson_id")
+    private Lesson lesson;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @JoinColumn(name = "objective_id")
+    private Objective objective;
+
+}

--- a/supabase/database/policies/lesson.sql
+++ b/supabase/database/policies/lesson.sql
@@ -10,8 +10,8 @@ CREATE POLICY "policy_edit_lessons"
     FOR ALL
     TO authenticated
     USING (
-            (SELECT check_user_role(auth.uid(), 'moderator')) = true OR
-            auth.uid() = user_id
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true OR
+    auth.uid() = user_id
     );
 
 DROP POLICY IF EXISTS "policy_lessons_example" ON public.lessons;
@@ -20,8 +20,8 @@ CREATE POLICY "policy_lessons_example"
     FOR SELECT
     TO authenticated
     USING (
-        (SELECT check_user_role(auth.uid(), 'teacher')) = true AND
-        (SELECT example) = true
+    (SELECT check_user_role(auth.uid(), 'teacher')) = true AND
+    (SELECT example) = true
     );
 
 DROP POLICY IF EXISTS "policy_select_lessons" ON public.lessons;
@@ -30,8 +30,8 @@ CREATE POLICY "policy_select_lessons"
     FOR SELECT
     TO authenticated
     USING (
-        (SELECT get_teacher_uuid(auth.uid() )) = user_id AND
-        published = true
+    (SELECT get_teacher_uuid(auth.uid())) = user_id AND
+    published = true
     );
 
 DROP POLICY IF EXISTS "policy_questions" ON public.questions;
@@ -40,11 +40,9 @@ CREATE POLICY "policy_questions"
     FOR SELECT
     TO authenticated
     USING (
-    EXISTS(
-        SELECT 1
-        FROM lessons
-        WHERE questions.lesson_uuid = lessons.uuid
-    )
+    EXISTS(SELECT 1
+           FROM lessons
+           WHERE questions.lesson_uuid = lessons.uuid)
     );
 DROP POLICY IF EXISTS "policy_questions_edit" ON public.questions;
 CREATE POLICY "policy_questions_edit"
@@ -52,10 +50,64 @@ CREATE POLICY "policy_questions_edit"
     FOR ALL
     TO authenticated
     USING (
-    EXISTS(
-        SELECT 1
-        FROM lessons
-        WHERE questions.lesson_uuid = lessons.uuid AND
-        lessons.user_id = auth.uid()
-    )
+    EXISTS(SELECT 1
+           FROM lessons
+           WHERE questions.lesson_uuid = lessons.uuid
+             AND lessons.user_id = auth.uid())
     );
+
+DROP POLICY IF EXISTS "policy_lesson_objectives" ON public.lesson_objectives;
+CREATE POLICY "policy_lesson_objectives"
+    ON public.lesson_objectives
+    FOR ALL
+    TO authenticated
+    USING (
+    (SELECT check_user_role(auth.uid(), 'moderator')) = true OR
+    ((SELECT check_user_role(auth.uid(), 'teacher')) = true AND
+     auth.uid() = user_id)
+    );
+
+
+DROP POLICY IF EXISTS "policy_lesson_objectives_delete" ON public.lesson_objectives;
+CREATE POLICY "policy_lesson_objectives_delete"
+    ON public.lesson_objectives
+    FOR DELETE
+    TO authenticated
+    USING (
+    ((select check_user_role(auth.uid(), 'teacher')) = true)
+        AND
+    EXISTS(
+        (SELECT 1
+         FROM lessons
+                  JOIN lesson_objectives ON lessons.uuid = lesson_objectives.lesson_id
+         WHERE lessons.user_id = auth.uid())));
+
+DROP POLICY IF EXISTS "policy_lesson_objectives_update" ON public.lesson_objectives;
+CREATE POLICY "policy_lesson_objectives_update"
+    ON public.lesson_objectives
+    FOR UPDATE
+    TO authenticated
+    USING (
+    ((select check_user_role(auth.uid(), 'teacher')) = true)
+        AND
+    EXISTS(
+        (SELECT 1
+         FROM lessons
+                  JOIN lesson_objectives ON lessons.uuid = lesson_objectives.lesson_id
+         WHERE lessons.user_id = auth.uid())));
+
+DROP POLICY IF EXISTS "policy_lesson_objectives_insert" ON public.lesson_objectives;
+CREATE POLICY "policy_lesson_objectives_insert"
+    ON public.lesson_objectives
+    FOR INSERT
+    TO authenticated
+    WITH CHECK (
+        (select check_user_role(auth.uid(), 'teacher') = true)
+    );
+
+DROP POLICY IF EXISTS "policy_select_lesson_objectives" ON public.lesson_objectives;
+CREATE POLICY "policy_select_lesson_objectives"
+    ON public.lesson_objectives
+    FOR SELECT
+    TO authenticated
+    USING (true);


### PR DESCRIPTION
Lektionen besitzen nun nicht mehr ein Objective in ihrer Entität, sondern erhalten eine Beziehung zu mehreren Objectives mithilfe einer Zwischentabelle. 
Diese werden auch in der Lektionsübersicht angezeigt. Datenbankfunktionen wurden entsprechend angepasst. 
Zudem wurde die Datenbankabfrage optimiert, um direkt Lektionen und ihre Objectives zu erhalten.