### PR TITLE
grant points to all lesson objectives

### DIFF
--- a/app/src/stores/scenario.ts
+++ b/app/src/stores/scenario.ts
@@ -40,8 +40,6 @@ export const useScenarioStore = defineStore('scenario', {
                     if (authStore.isTeacher) {
                         scenario.svg = await BpmnStorageService.pull.getDiagramSvg(scenario);
                         scenario.studentProgressStatistics = scenarioStatistics?.find(stat => stat.scenarioId === scenario.id);
-
-                        console.log(scenarioStatistics);
                     }
                     this.scenarios.push(scenario);
                 }

--- a/app/src/stores/scenarioStatistic.ts
+++ b/app/src/stores/scenarioStatistic.ts
@@ -110,8 +110,6 @@ export const useScenarioStatisticStore = defineStore("scenario_statistic", {
                         : [];
 
                     this.currentScenarioStatistic = mapToScenarioUserStatistic(scenarioStatisticData, userAchievements, userObjectives);
-                    console.log("fetched stats")
-                    console.log(this.currentScenarioStatistic)
                 }
             }
         },
@@ -132,8 +130,6 @@ export const useScenarioStatisticStore = defineStore("scenario_statistic", {
             if (lessons) {
                 this.currentScenarioResults = mapStatisticToQuestionWithResult(this.currentScenarioStatistic, lessons);
             }
-            console.log("fetched lesres")
-            console.log(this.currentScenarioResults)
         }
     }
 });

--- a/app/src/stores/util.ts
+++ b/app/src/stores/util.ts
@@ -81,14 +81,17 @@ export const useUtilStore = defineStore({
             }
 
             switch (actionType) {
-                case('Lernziel'):
+                case('Objective'):
                     alertText = xp + " XP für Lernziel " + actionTitle + " erhalten!"
                     break;
                 case('Achievement'):
                     alertText = xp + " XP für Achievement " + actionTitle + " erhalten!";
                     break;
                 case('ReqPal Achievement'):
-                    alertText= xp + " XP für ReqPal Achievement " + actionTitle + " erhalten!";
+                    alertText = xp + " XP für ReqPal Achievement " + actionTitle + " erhalten!";
+                    break;
+                case('All lesson objectives'):
+                    alertText = xp + " XP für alle Lernziele dieser Lektion erhalten!";
                     break;
                 default:
                     alertText = xp + " XP erhalten!"

--- a/bpmn-server/src/main/java/inc/plab/bpmn/service/ActivityLogService.java
+++ b/bpmn-server/src/main/java/inc/plab/bpmn/service/ActivityLogService.java
@@ -39,8 +39,23 @@ public class ActivityLogService {
         xpActivityLog.setReceivedXp(receivedXp);
         xpActivityLog.setCreatedAt(OffsetDateTime.now());
         xpActivityLog.setUser(profile);
-        xpActivityLog.setAction("Lernziel: " + objective.getName());
+        xpActivityLog.setAction("Objective: " + objective.getName());
 
+        xpActivityLogRepository.save(xpActivityLog);
+    }
+
+    public void addLogEntryForAllLessonObjectives(int receivedXp, String userId) {
+        UUID userUUID = UUID.fromString(userId);
+
+        Optional<Profile> profileOptional = profileRepository.findById(userUUID);
+        Profile profile = profileOptional.orElseThrow(() -> new IllegalArgumentException("Profile not found"));
+
+        XpActivityLog xpActivityLog = new XpActivityLog();
+        xpActivityLog.setReceivedXp(receivedXp);
+        xpActivityLog.setCreatedAt(OffsetDateTime.now());
+        xpActivityLog.setUser(profile);
+
+        xpActivityLog.setAction("All lesson objectives");
         xpActivityLogRepository.save(xpActivityLog);
     }
 

--- a/bpmn-server/src/main/java/inc/plab/bpmn/service/LessonService.java
+++ b/bpmn-server/src/main/java/inc/plab/bpmn/service/LessonService.java
@@ -3,6 +3,9 @@ package inc.plab.bpmn.service;
 import inc.plab.bpmn.mapper.Answer;
 import inc.plab.bpmn.mapper.LessonAnswer;
 import inc.plab.bpmn.mapper.LessonMapper;
+import inc.plab.bpmn.model.lesson.Lesson;
+import inc.plab.bpmn.model.lesson.LessonObjective;
+import inc.plab.bpmn.model.lesson.LessonRepository;
 import inc.plab.bpmn.model.question.evaluation.*;
 import inc.plab.bpmn.model.question.evaluation.result.*;
 import inc.plab.bpmn.validation.JsonValidator;
@@ -16,6 +19,11 @@ import java.util.*;
 @AllArgsConstructor
 public class LessonService {
     final EvaluationService evaluationService;
+    final LessonRepository lessonRepository;
+    final LevelService levelService;
+    final ScenarioUserStatisticsService scenarioUserStatisticsService;
+    final ActivityLogService activityLogService;
+    final UserStatisticService userStatisticService;
 
     public LessonResult evaluateLesson(String lessonId, SpinJsonNode lessonAnswer) {
         JsonValidator.validateJson(lessonAnswer.toString());
@@ -33,5 +41,21 @@ public class LessonService {
             }
         }
         return lessonResult;
+    }
+
+    public void grantPointsAsXpToLessonObjectives(String lessonId, int points, String userId, String scenarioId) {
+        Optional<Lesson> lessonOptional = lessonRepository.findByUuid(UUID.fromString(lessonId));
+        Lesson lesson = lessonOptional.orElseThrow(() -> new IllegalArgumentException("Lesson not found"));
+
+        Set<LessonObjective> lessonObjectives = lesson.getLessonObjectives();
+        if (!lessonObjectives.isEmpty()) {
+            for (LessonObjective objective : lessonObjectives) {
+                String objectiveId = String.valueOf(objective.getObjective().getId());
+                levelService.addXpToObjectiveForUser(points, objectiveId, userId);
+                userStatisticService.addToTotalObjectiveXp(points, userId);
+                scenarioUserStatisticsService.addObjectiveAndXp(objectiveId, points, userId, scenarioId);
+            }
+            activityLogService.addLogEntryForAllLessonObjectives(points, userId);
+        }
     }
 }


### PR DESCRIPTION
LessonService wurde erweitert und kann nun die erreichte Punktzahl in der Lektion allen Lernzielen der Lektion zuordnen, wenn das flag gesetzt wurde. Wenn es keine Lernziele gibt, wird nichts verteilt. 
Die Punkte werden auch den Statistiken zugerechnet und es wird ein Log Eintrag erstellt, der auf alle Lernziele hinweist.
Sind die Punkte nicht größer als 0, wird auch nichts weiter betrachtet.